### PR TITLE
separate update group name and group members dialog (add and remove m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 Session integrates directly with [Loki Service Nodes](https://lokidocs.com/ServiceNodes/SNOverview/), which are a set of distributed, decentralized and Sybil resistant nodes. Service Nodes act as servers which store messages offline, and a set of nodes which allow for onion routing functionality obfuscating users IP Addresses. For a full understanding of how Session works, read the [Session Whitepaper](https://getsession.org/whitepaper).
 ![DesktopSession](https://i.imgur.com/ZnHvYjo.jpg)
 
-
 ## Want to Contribute? Found a Bug or Have a feature request?
 
 Please search for any [existing issues](https://github.com/loki-project/session-desktop/issues) that describe your bugs in order to avoid duplicate submissions. Submissions can be made by making a pull request to our development branch. If you don't know where to start contributing , try reading the Github issues page for ideas.

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2204,12 +2204,16 @@
     "message": "Edit Profile",
     "description": "Button action that the user can click to edit their profile"
   },
+  "editGroupName": {
+    "message": "Edit group name",
+    "description": "Button action that the user can click to edit a group name"
+  },
   "createGroupDialogTitle": {
-    "message": "Creating a Private Group Chat",
+    "message": "Creating a Closed Group",
     "description": "Title for the dialog box used to create a new private group"
   },
   "updateGroupDialogTitle": {
-    "message": "Updating a Private Group Chat",
+    "message": "Updating a Closed Group",
     "description":
       "Title for the dialog box used to update an existing private group"
   },
@@ -2528,6 +2532,9 @@
   },
   "noFriendsToAdd": {
     "message": "No friends to add"
+  },
+  "noMembersInThisGroup": {
+    "message": "No other members in this group"
   },
   "noModeratorsToRemove": {
     "message": "no moderators to remove"

--- a/js/background.js
+++ b/js/background.js
@@ -1135,9 +1135,14 @@
       }
     });
 
-    Whisper.events.on('updateGroup', async groupConvo => {
+    Whisper.events.on('updateGroupName', async groupConvo => {
       if (appView) {
-        appView.showUpdateGroupDialog(groupConvo);
+        appView.showUpdateGroupNameDialog(groupConvo);
+      }
+    });
+    Whisper.events.on('updateGroupMembers', async groupConvo => {
+      if (appView) {
+        appView.showUpdateGroupMembersDialog(groupConvo);
       }
     });
 

--- a/js/modules/signal.js
+++ b/js/modules/signal.js
@@ -34,8 +34,8 @@ const {
   ConversationHeader,
 } = require('../../ts/components/conversation/ConversationHeader');
 const {
-  SessionChannelSettings,
-} = require('../../ts/components/session/SessionChannelSettings');
+  SessionGroupSettings,
+} = require('../../ts/components/session/SessionGroupSettings');
 const {
   EmbeddedContact,
 } = require('../../ts/components/conversation/EmbeddedContact');
@@ -93,8 +93,11 @@ const {
 } = require('../../ts/components/session/SessionRegistrationView');
 
 const {
-  UpdateGroupDialog,
-} = require('../../ts/components/conversation/UpdateGroupDialog');
+  UpdateGroupNameDialog,
+} = require('../../ts/components/conversation/UpdateGroupNameDialog');
+const {
+  UpdateGroupMembersDialog,
+} = require('../../ts/components/conversation/UpdateGroupMembersDialog');
 const {
   InviteFriendsDialog,
 } = require('../../ts/components/conversation/InviteFriendsDialog');
@@ -278,7 +281,7 @@ exports.setup = (options = {}) => {
     ContactListItem,
     ContactName,
     ConversationHeader,
-    SessionChannelSettings,
+    SessionGroupSettings,
     SettingsView,
     EmbeddedContact,
     Emojify,
@@ -293,7 +296,8 @@ exports.setup = (options = {}) => {
     DevicePairingDialog,
     SessionRegistrationView,
     ConfirmDialog,
-    UpdateGroupDialog,
+    UpdateGroupNameDialog,
+    UpdateGroupMembersDialog,
     InviteFriendsDialog,
     AddModeratorsDialog,
     RemoveModeratorsDialog,

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -228,10 +228,15 @@
       const dialog = new Whisper.CreateGroupDialogView();
       this.el.append(dialog.el);
     },
-    showUpdateGroupDialog(groupConvo) {
-      const dialog = new Whisper.UpdateGroupDialogView(groupConvo);
-      this.el.prepend(dialog.el);
+    showUpdateGroupNameDialog(groupConvo) {
+      const dialog = new Whisper.UpdateGroupNameDialogView(groupConvo);
+      this.el.append(dialog.el);
     },
+    showUpdateGroupMembersDialog(groupConvo) {
+      const dialog = new Whisper.UpdateGroupMembersDialogView(groupConvo);
+      this.el.append(dialog.el);
+    },
+
     showSessionRestoreConfirmation(options) {
       const dialog = new Whisper.ConfirmSessionResetView(options);
       this.el.append(dialog.el);

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -244,11 +244,6 @@
           onMoveToInbox: () => {
             this.model.setArchived(false);
           },
-
-          onUpdateGroup: () => {
-            window.Whisper.events.trigger('updateGroup', this.model);
-          },
-
           onLeaveGroup: () => {
             window.Whisper.events.trigger('leaveGroup', this.model);
           },
@@ -276,7 +271,8 @@
           },
         };
       };
-      const getGroupSettingsProp = () => {
+      const getGroupSettingsProps = () => {
+        const ourPK = window.textsecure.storage.user.getNumber();
         const members = this.model.get('members') || [];
 
         return {
@@ -288,6 +284,7 @@
           avatarPath: this.model.getAvatarPath(),
           isGroup: !this.model.isPrivate(),
           isPublic: this.model.isPublic(),
+          isAdmin: this.model.get('groupAdmins').includes(ourPK),
           isRss: this.model.isRss(),
           memberCount: members.length,
 
@@ -303,8 +300,11 @@
             this.$('.conversation-content-right').hide();
           },
 
-          onUpdateGroup: () => {
-            window.Whisper.events.trigger('updateGroup', this.model);
+          onUpdateGroupName: () => {
+            window.Whisper.events.trigger('updateGroupName', this.model);
+          },
+          onUpdateGroupMembers: () => {
+            window.Whisper.events.trigger('updateGroupMembers', this.model);
           },
 
           onLeaveGroup: () => {
@@ -344,12 +344,15 @@
         if (!this.groupSettings) {
           this.groupSettings = new Whisper.ReactWrapperView({
             className: 'group-settings',
-            Component: window.Signal.Components.SessionChannelSettings,
-            props: getGroupSettingsProp(this.model),
+            Component: window.Signal.Components.SessionGroupSettings,
+            props: getGroupSettingsProps(this.model),
           });
           this.$('.conversation-content-right').append(this.groupSettings.el);
+          this.updateGroupSettingsPanel = () =>
+            this.groupSettings.update(getGroupSettingsProps(this.model));
+          this.listenTo(this.model, 'change', this.updateGroupSettingsPanel);
         } else {
-          this.groupSettings.update(getGroupSettingsProp(this.model));
+          this.groupSettings.update(getGroupSettingsProps(this.model));
         }
         this.$('.conversation-content-right').show();
       };

--- a/js/views/create_group_dialog_view.js
+++ b/js/views/create_group_dialog_view.js
@@ -47,13 +47,13 @@
     },
   });
 
-  Whisper.UpdateGroupDialogView = Whisper.View.extend({
+  Whisper.UpdateGroupNameDialogView = Whisper.View.extend({
     className: 'loki-dialog modal',
     initialize(groupConvo) {
       this.groupName = groupConvo.get('name');
 
       this.conversation = groupConvo;
-      this.titleText = `${i18n('updateGroupDialogTitle')}: ${this.groupName}`;
+      this.titleText = i18n('updateGroupDialogTitle');
       this.okText = i18n('ok');
       this.cancelText = i18n('cancel');
       this.close = this.close.bind(this);
@@ -106,7 +106,90 @@
     render() {
       this.dialogView = new Whisper.ReactWrapperView({
         className: 'create-group-dialog',
-        Component: window.Signal.Components.UpdateGroupDialog,
+        Component: window.Signal.Components.UpdateGroupNameDialog,
+        props: {
+          titleText: this.titleText,
+          groupName: this.groupName,
+          okText: this.okText,
+          isPublic: this.isPublic,
+          cancelText: this.cancelText,
+          existingMembers: this.existingMembers,
+          isAdmin: this.isAdmin,
+          onClose: this.close,
+          onSubmit: this.onSubmit,
+        },
+      });
+
+      this.$el.append(this.dialogView.el);
+      return this;
+    },
+    onSubmit(newGroupName, members) {
+      const groupId = this.conversation.get('id');
+
+      window.doUpdateGroup(groupId, newGroupName, members);
+    },
+    close() {
+      this.remove();
+    },
+  });
+
+  Whisper.UpdateGroupMembersDialogView = Whisper.View.extend({
+    className: 'loki-dialog modal',
+    initialize(groupConvo) {
+      this.groupName = groupConvo.get('name');
+
+      this.conversation = groupConvo;
+      this.titleText = i18n('updateGroupDialogTitle');
+      this.okText = i18n('ok');
+      this.cancelText = i18n('cancel');
+      this.close = this.close.bind(this);
+      this.onSubmit = this.onSubmit.bind(this);
+      this.isPublic = groupConvo.isPublic();
+
+      const ourPK = textsecure.storage.user.getNumber();
+
+      this.isAdmin = groupConvo.get('groupAdmins').includes(ourPK);
+
+      const convos = window.getConversations().models.filter(d => !!d);
+
+      let existingMembers = groupConvo.get('members') || [];
+
+      // Show a contact if they are our friend or if they are a member
+      const friendsAndMembers = convos.filter(
+        d => existingMembers.includes(d.id) && d.isPrivate() && !d.isMe()
+      );
+      this.friendsAndMembers = _.uniq(friendsAndMembers, true, d => d.id);
+
+      // at least make sure it's an array
+      if (!Array.isArray(existingMembers)) {
+        existingMembers = [];
+      }
+
+      this.existingMembers = existingMembers;
+
+      // public chat settings overrides
+      if (this.isPublic) {
+        // fix the title
+        this.titleText = `${i18n('updatePublicGroupDialogTitle')}: ${
+          this.groupName
+        }`;
+        // I'd much prefer to integrate mods with groupAdmins
+        // but lets discuss first...
+        this.isAdmin = groupConvo.isModerator(
+          window.storage.get('primaryDevicePubKey')
+        );
+        // zero out friendList for now
+        this.friendsAndMembers = [];
+        this.existingMembers = [];
+      }
+
+      this.$el.focus();
+      this.render();
+    },
+    render() {
+      this.dialogView = new Whisper.ReactWrapperView({
+        className: 'create-group-dialog',
+        Component: window.Signal.Components.UpdateGroupMembersDialog,
         props: {
           titleText: this.titleText,
           groupName: this.groupName,
@@ -124,12 +207,12 @@
       this.$el.append(this.dialogView.el);
       return this;
     },
-    onSubmit(newGroupName, newMembers) {
+    onSubmit(groupName, newMembers) {
       const ourPK = textsecure.storage.user.getNumber();
       const allMembers = window.Lodash.concat(newMembers, [ourPK]);
       const groupId = this.conversation.get('id');
 
-      window.doUpdateGroup(groupId, newGroupName, allMembers);
+      window.doUpdateGroup(groupId, groupName, allMembers);
     },
     close() {
       this.remove();

--- a/js/views/invite_friends_dialog_view.js
+++ b/js/views/invite_friends_dialog_view.js
@@ -1,4 +1,4 @@
-/* global Whisper */
+/* global Whisper, _ */
 
 // eslint-disable-next-line func-names
 (function() {
@@ -22,6 +22,8 @@
       this.chatName = convo.get('name');
       this.chatServer = convo.get('server');
       this.channelId = convo.get('channelId');
+      this.isPublic = !!convo.cachedProps.isPublic;
+      this.convo = convo;
 
       this.$el.focus();
       this.render();
@@ -45,14 +47,56 @@
       this.remove();
     },
     submit(pubkeys) {
-      window.sendGroupInvitations(
-        {
-          address: this.chatServer,
-          name: this.chatName,
-          channelId: this.channelId,
-        },
-        pubkeys
-      );
+      // public group chats
+      if (this.isPublic) {
+        window.sendGroupInvitations(
+          {
+            address: this.chatServer,
+            name: this.chatName,
+            channelId: this.channelId,
+          },
+          pubkeys
+        );
+      } else {
+        // private group chats
+        const ourPK = window.textsecure.storage.user.getNumber();
+        let existingMembers = this.convo.get('members') || [];
+        // at least make sure it's an array
+        if (!Array.isArray(existingMembers)) {
+          existingMembers = [];
+        }
+        existingMembers = existingMembers.filter(d => !!d);
+        const newMembers = pubkeys.filter(d => !existingMembers.includes(d));
+
+        if (newMembers.length > 0) {
+          // Do not trigger an update if there is too many members
+          if (
+            newMembers.length + existingMembers.length >
+            window.SMALL_GROUP_SIZE_LIMIT
+          ) {
+            const msg = `${window.i18n('maxGroupMembersError')} ${
+              window.SMALL_GROUP_SIZE_LIMIT
+            }`;
+
+            window.pushToast({
+              title: msg,
+              type: 'error',
+              id: 'tooManyMembers',
+            });
+            return;
+          }
+
+          const allMembers = window.Lodash.concat(existingMembers, newMembers, [
+            ourPK,
+          ]);
+          const uniqMembers = _.uniq(allMembers, true, d => d);
+
+          const groupId = this.convo.get('id');
+          const groupName = this.convo.get('name');
+
+          window.doUpdateGroup(groupId, groupName, uniqMembers);
+        }
+      }
     },
   });
 })();

--- a/stylesheets/_session.scss
+++ b/stylesheets/_session.scss
@@ -794,6 +794,15 @@ label {
   }
 }
 
+.create-group-dialog .session-modal__body {
+  display: flex;
+  flex-direction: column;
+
+  .friend-selection-list {
+    width: unset;
+  }
+}
+
 .session-confirm {
   &-wrapper {
     .session-modal__body .session-modal__centered {

--- a/ts/components/conversation/ConversationHeader.tsx
+++ b/ts/components/conversation/ConversationHeader.tsx
@@ -32,7 +32,6 @@ interface Props {
 
   phoneNumber: string;
   profileName?: string;
-  color: string;
   avatarPath?: string;
 
   isVerified: boolean;
@@ -88,7 +87,6 @@ interface Props {
 
   onCopyPublicKey: () => void;
 
-  onUpdateGroup: () => void;
   onLeaveGroup: () => void;
   onAddModerators: () => void;
   onRemoveModerators: () => void;
@@ -206,7 +204,6 @@ export class ConversationHeader extends React.Component<Props> {
   public renderAvatar() {
     const {
       avatarPath,
-      color,
       i18n,
       isGroup,
       isMe,
@@ -223,7 +220,6 @@ export class ConversationHeader extends React.Component<Props> {
       <span className="module-conversation-header__avatar">
         <Avatar
           avatarPath={avatarPath}
-          color={color}
           conversationType={conversationType}
           i18n={i18n}
           noteToSelf={isMe}
@@ -305,7 +301,6 @@ export class ConversationHeader extends React.Component<Props> {
       onDeleteMessages,
       onDeleteContact,
       onCopyPublicKey,
-      onUpdateGroup,
       onLeaveGroup,
       onAddModerators,
       onRemoveModerators,
@@ -323,9 +318,6 @@ export class ConversationHeader extends React.Component<Props> {
           <MenuItem onClick={onCopyPublicKey}>{copyIdLabel}</MenuItem>
         ) : null}
         <MenuItem onClick={onDeleteMessages}>{i18n('deleteMessages')}</MenuItem>
-        {isPrivateGroup || amMod ? (
-          <MenuItem onClick={onUpdateGroup}>{i18n('updateGroup')}</MenuItem>
-        ) : null}
         {amMod ? (
           <MenuItem onClick={onAddModerators}>{i18n('addModerators')}</MenuItem>
         ) : null}

--- a/ts/components/conversation/UpdateGroupMembersDialog.tsx
+++ b/ts/components/conversation/UpdateGroupMembersDialog.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import classNames from 'classnames';
 import { Contact, MemberList } from './MemberList';
 
-import { SessionModal } from './../session/SessionModal';
+import { SessionModal } from '../session/SessionModal';
+import { SessionButton } from '../session/SessionButton';
 
 interface Props {
   titleText: string;
@@ -21,12 +22,11 @@ interface Props {
 
 interface State {
   friendList: Array<Contact>;
-  groupName: string;
   errorDisplayed: boolean;
   errorMessage: string;
 }
 
-export class UpdateGroupDialog extends React.Component<Props, State> {
+export class UpdateGroupMembersDialog extends React.Component<Props, State> {
   constructor(props: any) {
     super(props);
 
@@ -57,7 +57,6 @@ export class UpdateGroupDialog extends React.Component<Props, State> {
 
     this.state = {
       friendList: friends,
-      groupName: this.props.groupName,
       errorDisplayed: false,
       errorMessage: 'placeholder',
     };
@@ -70,13 +69,7 @@ export class UpdateGroupDialog extends React.Component<Props, State> {
       d => d.id
     );
 
-    if (!this.state.groupName.trim()) {
-      this.onShowError(this.props.i18n('emptyGroupNameError'));
-
-      return;
-    }
-
-    this.props.onSubmit(this.state.groupName, members);
+    this.props.onSubmit(this.props.groupName, members);
 
     this.closeDialog();
   }
@@ -111,24 +104,15 @@ export class UpdateGroupDialog extends React.Component<Props, State> {
     );
 
     return (
-      <SessionModal title={titleText} onClose={() => null} onOk={() => null}>
+      <SessionModal
+        title={titleText}
+        // tslint:disable-next-line: no-void-expression
+        onClose={() => this.closeDialog()}
+        onOk={() => null}
+      >
         <div className="spacer-md" />
         <p className={errorMessageClasses}>{errorMsg}</p>
         <div className="spacer-md" />
-
-        <input
-          type="text"
-          id="group-name"
-          className="group-name"
-          placeholder={this.props.i18n('groupNamePlaceholder')}
-          value={this.state.groupName}
-          disabled={!this.props.isAdmin}
-          onChange={this.onGroupNameChanged}
-          tabIndex={0}
-          required={true}
-          aria-required={true}
-          autoFocus={true}
-        />
 
         <div className="friend-selection-list">
           <MemberList
@@ -139,15 +123,13 @@ export class UpdateGroupDialog extends React.Component<Props, State> {
           />
         </div>
         <p className={noFriendsClasses}>{`(${this.props.i18n(
-          'noFriendsToAdd'
+          'noMembersInThisGroup'
         )})`}</p>
-        <div className="buttons">
-          <button className="cancel" tabIndex={0} onClick={this.closeDialog}>
-            {cancelText}
-          </button>
-          <button className="ok" tabIndex={0} onClick={this.onClickOK}>
-            {okText}
-          </button>
+
+        <div className="session-modal__button-group">
+          <SessionButton text={okText} onClick={this.onClickOK} />
+
+          <SessionButton text={cancelText} onClick={this.closeDialog} />
         </div>
       </SessionModal>
     );

--- a/ts/components/conversation/UpdateGroupNameDialog.tsx
+++ b/ts/components/conversation/UpdateGroupNameDialog.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import { SessionModal } from '../session/SessionModal';
+import { SessionButton } from '../session/SessionButton';
+
+interface Props {
+  titleText: string;
+  groupName: string;
+  okText: string;
+  cancelText: string;
+  isAdmin: boolean;
+  i18n: any;
+  onSubmit: any;
+  onClose: any;
+  existingMembers: Array<String>;
+}
+
+interface State {
+  groupName: string;
+  errorDisplayed: boolean;
+  errorMessage: string;
+}
+
+export class UpdateGroupNameDialog extends React.Component<Props, State> {
+  constructor(props: any) {
+    super(props);
+
+    this.onClickOK = this.onClickOK.bind(this);
+    this.onKeyUp = this.onKeyUp.bind(this);
+    this.closeDialog = this.closeDialog.bind(this);
+    this.onGroupNameChanged = this.onGroupNameChanged.bind(this);
+
+    this.state = {
+      groupName: this.props.groupName,
+      errorDisplayed: false,
+      errorMessage: 'placeholder',
+    };
+
+    window.addEventListener('keyup', this.onKeyUp);
+  }
+
+  public onClickOK() {
+    if (!this.state.groupName.trim()) {
+      this.onShowError(this.props.i18n('emptyGroupNameError'));
+
+      return;
+    }
+
+    this.props.onSubmit(this.state.groupName, this.props.existingMembers);
+
+    this.closeDialog();
+  }
+
+  public render() {
+    const okText = this.props.okText;
+    const cancelText = this.props.cancelText;
+
+    let titleText;
+
+    titleText = `${this.props.titleText}`;
+
+    const errorMsg = this.state.errorMessage;
+    const errorMessageClasses = classNames(
+      'error-message',
+      this.state.errorDisplayed ? 'error-shown' : 'error-faded'
+    );
+
+    return (
+      <SessionModal
+        title={titleText}
+        // tslint:disable-next-line: no-void-expression
+        onClose={() => this.closeDialog()}
+        onOk={() => null}
+      >
+        <div className="spacer-md" />
+        <p className={errorMessageClasses}>{errorMsg}</p>
+        <div className="spacer-md" />
+
+        <input
+          type="text"
+          className="profile-name-input"
+          value={this.state.groupName}
+          placeholder={this.props.i18n('groupNamePlaceholder')}
+          onChange={this.onGroupNameChanged}
+          tabIndex={0}
+          required={true}
+          aria-required={true}
+          autoFocus={true}
+          disabled={!this.props.isAdmin}
+        />
+
+        <div className="session-modal__button-group">
+          <SessionButton text={okText} onClick={this.onClickOK} />
+
+          <SessionButton text={cancelText} onClick={this.closeDialog} />
+        </div>
+      </SessionModal>
+    );
+  }
+
+  private onShowError(msg: string) {
+    if (this.state.errorDisplayed) {
+      return;
+    }
+
+    this.setState({
+      errorDisplayed: true,
+      errorMessage: msg,
+    });
+
+    setTimeout(() => {
+      this.setState({
+        errorDisplayed: false,
+      });
+    }, 3000);
+  }
+
+  private onKeyUp(event: any) {
+    switch (event.key) {
+      case 'Enter':
+        this.onClickOK();
+        break;
+      case 'Esc':
+      case 'Escape':
+        this.closeDialog();
+        break;
+      default:
+    }
+  }
+
+  private closeDialog() {
+    window.removeEventListener('keyup', this.onKeyUp);
+
+    this.props.onClose();
+  }
+
+  private onGroupNameChanged(event: any) {
+    event.persist();
+
+    this.setState(state => {
+      return {
+        ...state,
+        groupName: event.target.value,
+      };
+    });
+  }
+}

--- a/ts/components/session/SessionGroupSettings.tsx
+++ b/ts/components/session/SessionGroupSettings.tsx
@@ -19,15 +19,18 @@ interface Props {
   avatarPath: string;
   timerOptions: Array<TimerOption>;
   isPublic: boolean;
+  isAdmin: boolean;
 
   onGoBack: () => void;
   onInviteFriends: () => void;
   onLeaveGroup: () => void;
+  onUpdateGroupName: () => void;
+  onUpdateGroupMembers: () => void;
   onShowLightBox: (options: any) => void;
   onSetDisappearingMessages: (seconds: number) => void;
 }
 
-export class SessionChannelSettings extends React.Component<Props, any> {
+export class SessionGroupSettings extends React.Component<Props, any> {
   public constructor(props: Props) {
     super(props);
 
@@ -207,6 +210,7 @@ export class SessionChannelSettings extends React.Component<Props, any> {
       timerOptions,
       onLeaveGroup,
       isPublic,
+      isAdmin,
     } = this.props;
     const { documents, media, onItemClick } = this.state;
     const showMemberCount = !!(memberCount && memberCount > 0);
@@ -231,7 +235,7 @@ export class SessionChannelSettings extends React.Component<Props, any> {
         {showMemberCount && (
           <>
             <div className="spacer-lg" />
-            <div className="text-subtle">
+            <div role="button" className="text-subtle">
               {window.i18n('members', memberCount)}
             </div>
             <div className="spacer-lg" />
@@ -241,7 +245,26 @@ export class SessionChannelSettings extends React.Component<Props, any> {
           className="description"
           placeholder={window.i18n('description')}
         />
-
+        {!isPublic && (
+          <>
+            {isAdmin && (
+              <div
+                className="group-settings-item"
+                role="button"
+                onClick={this.props.onUpdateGroupName}
+              >
+                {window.i18n('editGroupName')}
+              </div>
+            )}
+            <div
+              className="group-settings-item"
+              role="button"
+              onClick={this.props.onUpdateGroupMembers}
+            >
+              {window.i18n('showMembers')}
+            </div>
+          </>
+        )}
         <div className="group-settings-item">
           {window.i18n('notifications')}
         </div>
@@ -269,8 +292,16 @@ export class SessionChannelSettings extends React.Component<Props, any> {
   }
 
   private renderHeader() {
-    const { id, onGoBack, onInviteFriends, avatarPath } = this.props;
-    const shouldShowInviteFriends = !this.props.isPublic;
+    const {
+      id,
+      onGoBack,
+      onInviteFriends,
+      avatarPath,
+      isAdmin,
+      isPublic,
+    } = this.props;
+
+    const showInviteFriends = isPublic || isAdmin;
 
     return (
       <div className="group-settings-header">
@@ -286,9 +317,8 @@ export class SessionChannelSettings extends React.Component<Props, any> {
           conversationType="group"
           size={80}
         />
-
         <div className="invite-friends-container">
-          {shouldShowInviteFriends && (
+          {showInviteFriends && (
             <SessionIconButton
               iconType={SessionIconType.AddUser}
               iconSize={SessionIconSize.Medium}


### PR DESCRIPTION
Add two options in the group panel (visible for closed chats only)
* update group name
* show members

The show members only allows to remove existing members.
To add new members, use the addMemberButton (equivalent to the invite member for open groups). The dialog will trigger an invite for the user if OpenGroup or add the user to the group if this is a ClosedGroup.