### PR TITLE
Refactor session reset handling

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,7 +63,7 @@ module.exports = {
         // high value as a buffer to let Prettier control the line length:
         code: 999,
         // We still want to limit comments as before:
-        comments: 90,
+        comments: 150,
         ignoreUrls: true,
         ignoreRegExpLiterals: true,
       },

--- a/js/modules/metadata/SecretSessionCipher.js
+++ b/js/modules/metadata/SecretSessionCipher.js
@@ -475,7 +475,6 @@ SecretSessionCipher.prototype = {
 
   // private byte[] decrypt(UnidentifiedSenderMessageContent message)
   _decryptWithUnidentifiedSenderMessage(message) {
-    const { SessionCipher } = this;
     const signalProtocolStore = this.storage;
 
     const sender = new libsignal.SignalProtocolAddress(
@@ -485,12 +484,12 @@ SecretSessionCipher.prototype = {
 
     switch (message.type) {
       case CiphertextMessage.WHISPER_TYPE:
-        return new SessionCipher(
+        return new libloki.crypto.LokiSessionCipher(
           signalProtocolStore,
           sender
         ).decryptWhisperMessage(message.content);
       case CiphertextMessage.PREKEY_TYPE:
-        return new SessionCipher(
+        return new libloki.crypto.LokiSessionCipher(
           signalProtocolStore,
           sender
         ).decryptPreKeyWhisperMessage(message.content);

--- a/libloki/crypto.js
+++ b/libloki/crypto.js
@@ -359,7 +359,10 @@
         );
       }
 
-      const decryptFunction = type === this.TYPE.PREKEY ? this.sessionCipher.decryptPreKeyWhisperMessage : this.sessionCipher.decryptWhisperMessage;
+      const decryptFunction =
+        type === this.TYPE.PREKEY
+          ? this.sessionCipher.decryptPreKeyWhisperMessage
+          : this.sessionCipher.decryptWhisperMessage;
       const result = await decryptFunction(buffer, encoding);
 
       // Handle session reset

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1361,6 +1361,7 @@ MessageReceiver.prototype.extend({
         content.preKeyBundleMessage
       );
     }
+
     if (content.lokiAddressMessage) {
       return this.handleLokiAddressMessage(
         envelope,
@@ -1724,7 +1725,7 @@ MessageReceiver.prototype.extend({
           textsecure.storage.protocol,
           address
         );
-        builder.processPreKey(device);
+        await builder.processPreKey(device);
       })
     );
     await conversation.onSessionResetReceived();

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -1041,64 +1041,6 @@ MessageSender.prototype = {
       silent,
       options
     ).catch(logError('resetSession/sendToContact error:'));
-    /*
-    const deleteAllSessions = targetNumber =>
-      textsecure.storage.protocol.getDeviceIds(targetNumber).then(deviceIds =>
-        Promise.all(
-          deviceIds.map(deviceId => {
-            const address = new libsignal.SignalProtocolAddress(
-              targetNumber,
-              deviceId
-            );
-            window.log.info('deleting sessions for', address.toString());
-            const sessionCipher = new libsignal.SessionCipher(
-              textsecure.storage.protocol,
-              address
-            );
-            return sessionCipher.deleteAllSessionsForDevice();
-          })
-        )
-      );
-
-    const sendToContactPromise = deleteAllSessions(number)
-      .catch(logError('resetSession/deleteAllSessions1 error:'))
-      .then(() => {
-        window.log.info(
-          'finished closing local sessions, now sending to contact'
-        );
-        return this.sendIndividualProto(
-          number,
-          proto,
-          timestamp,
-          silent,
-          options
-        ).catch(logError('resetSession/sendToContact error:'));
-      })
-      .then(() =>
-        deleteAllSessions(number).catch(
-          logError('resetSession/deleteAllSessions2 error:')
-        )
-      );
-
-    const myNumber = textsecure.storage.user.getNumber();
-    // We already sent the reset session to our other devices in the code above!
-    if (number === myNumber) {
-      return sendToContactPromise;
-    }
-
-    const buffer = proto.toArrayBuffer();
-    const sendSyncPromise = this.sendSyncMessage(
-      buffer,
-      timestamp,
-      number,
-      null,
-      [],
-      [],
-      options
-    ).catch(logError('resetSession/sendSync error:'));
-
-    return Promise.all([sendToContact, sendSyncPromise]);
-    */
   },
 
   async sendMessageToGroup(


### PR DESCRIPTION
Moved session reset out from `message_receiver` into a custom `LokiSessionCipher`.
I didn't want to modify `SessionCipher` directly since it resides in `libsignal-protocol.js`.

There's also a minor fix that i forgot in #838 