### PR TITLE
change the user-select to text

### DIFF
--- a/stylesheets/_session.scss
+++ b/stylesheets/_session.scss
@@ -194,7 +194,7 @@ a,
 div,
 span,
 label {
-  user-select: none;
+  user-select: text;
 
   &::selection {
     background: $session-shade-17;


### PR DESCRIPTION
change span css property user-select from none to text and this enables all the copy and paste behaviour
see the original issue post: 
https://github.com/loki-project/session-desktop/issues/801