### PR TITLE
Reverting changes in pull #336

### DIFF
--- a/main.js
+++ b/main.js
@@ -428,7 +428,7 @@ ipc.on('ready-for-updates', async () => {
 
 function openReleaseNotes() {
   shell.openExternal(
-    `https://github.com/loki-project/loki-messenger/releases/tag/${app.getVersion()}`
+    `https://github.com/loki-project/loki-messenger/releases/tag/v${app.getVersion()}`
   );
 }
 


### PR DESCRIPTION
As suggested, with that old commit in https://github.com/loki-project/session-desktop/pull/336  the "Go to Release Notes" link is broken referencing to "https://github.com/loki-project/session-desktop/releases/tag/1.0.1" for example.
