### PR TITLE
Closed group syncing

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1371,6 +1371,8 @@
       await window.lokiFileServerAPI.updateOurDeviceMapping();
       // TODO: we should ensure the message was sent and retry automatically if not
       await libloki.api.sendUnpairingMessageToSecondary(pubKey);
+      // Remove all traces of the device
+      ConversationController.deleteContact(pubKey);
       Whisper.events.trigger('refreshLinkedDeviceList');
     });
   }

--- a/js/background.js
+++ b/js/background.js
@@ -787,6 +787,7 @@
         'group'
       );
 
+      convo.updateGroupAdmins([primaryDeviceKey]);
       convo.updateGroup(ev.groupDetails);
 
       // Group conversations are automatically 'friends'
@@ -794,8 +795,6 @@
       convo.setFriendRequestStatus(
         window.friends.friendRequestStatusEnum.friends
       );
-
-      convo.updateGroupAdmins([primaryDeviceKey]);
 
       appView.openConversation(groupId, {});
     };

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -2232,11 +2232,27 @@
             this.get('name'),
             this.get('avatar'),
             this.get('members'),
+            this.get('groupAdmins'),
             groupUpdate.recipients,
             options
           )
         )
       );
+    },
+
+    sendGroupInfo(recipients) {
+      if (this.isClosedGroup()) {
+        const options = this.getSendOptions();
+        textsecure.messaging.updateGroup(
+          this.id,
+          this.get('name'),
+          this.get('avatar'),
+          this.get('members'),
+          this.get('groupAdmins'),
+          recipients,
+          options
+        );
+      }
     },
 
     async leaveGroup() {
@@ -2323,6 +2339,7 @@
         const ourNumber = textsecure.storage.user.getNumber();
         return !stillUnread.some(
           m =>
+            m.propsForMessage &&
             m.propsForMessage.text &&
             m.propsForMessage.text.indexOf(`@${ourNumber}`) !== -1
         );

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -221,9 +221,7 @@
       return !!(this.id && this.id.match(/^publicChat:/));
     },
     isClosedGroup() {
-      return (
-        this.get('type') === Message.GROUP && !this.isPublic() && !this.isRss()
-      );
+      return this.get('type') === Message.GROUP && !this.isPublic() && !this.isRss();
     },
     isClosable() {
       return !this.isRss() || this.get('closable');

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -221,7 +221,9 @@
       return !!(this.id && this.id.match(/^publicChat:/));
     },
     isClosedGroup() {
-      return this.get('type') === Message.GROUP && !this.isPublic() && !this.isRss();
+      return (
+        this.get('type') === Message.GROUP && !this.isPublic() && !this.isRss()
+      );
     },
     isClosable() {
       return !this.isRss() || this.get('closable');

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -935,7 +935,7 @@
         if (newStatus === FriendRequestStatusEnum.friends) {
           if (!blockSync) {
             // Sync contact
-            this.wrapSend(textsecure.messaging.sendContactSyncMessage(this));
+            this.wrapSend(textsecure.messaging.sendContactSyncMessage([this]));
           }
           // Only enable sending profileKey after becoming friends
           this.set({ profileSharing: true });

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -2008,7 +2008,7 @@
             }
           });
         } else if (newGroup) {
-          // We have an unknown group, we should request info
+          // We have an unknown group, we should request info from the sender
           textsecure.messaging.requestGroupInfo(conversationId, [
             primarySource,
           ]);

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -1929,78 +1929,90 @@
         }
       }
 
-      if (
-        initialMessage.group &&
-        initialMessage.group.members &&
-        initialMessage.group.type === GROUP_TYPES.UPDATE
-      ) {
-        if (newGroup) {
-          conversation.updateGroupAdmins(initialMessage.group.admins);
+      if (initialMessage.group) {
+        if (
+          initialMessage.group.type === GROUP_TYPES.REQUEST_INFO &&
+          !newGroup
+        ) {
+          conversation.sendGroupInfo([source]);
+          return null;
+        } else if (
+          initialMessage.group.members &&
+          initialMessage.group.type === GROUP_TYPES.UPDATE
+        ) {
+          if (newGroup) {
+            conversation.updateGroupAdmins(initialMessage.group.admins);
 
-          conversation.setFriendRequestStatus(
-            window.friends.friendRequestStatusEnum.friends
-          );
-        }
+            conversation.setFriendRequestStatus(
+              window.friends.friendRequestStatusEnum.friends
+            );
+          }
 
         const fromAdmin = conversation
           .get('groupAdmins')
           .includes(primarySource);
 
-        if (!fromAdmin) {
-          // Make sure the message is not removing members / renaming the group
-          const nameChanged =
-            conversation.get('name') !== initialMessage.group.name;
+          if (!fromAdmin) {
+            // Make sure the message is not removing members / renaming the group
+            const nameChanged =
+              conversation.get('name') !== initialMessage.group.name;
 
-          if (nameChanged) {
-            window.log.warn(
-              'Non-admin attempts to change the name of the group'
-            );
-          }
-
-          const membersMissing =
-            _.difference(
-              conversation.get('members'),
-              initialMessage.group.members
-            ).length > 0;
-
-          if (membersMissing) {
-            window.log.warn('Non-admin attempts to remove group members');
-          }
-
-          const messageAllowed = !nameChanged && !membersMissing;
-
-          if (!messageAllowed) {
-            confirm();
-            return null;
-          }
-        }
-        // For every member, see if we need to establish a session:
-        initialMessage.group.members.forEach(memberPubKey => {
-          const haveSession = _.some(
-            textsecure.storage.protocol.sessions,
-            s => s.number === memberPubKey
-          );
-
-          const ourPubKey = textsecure.storage.user.getNumber();
-          if (!haveSession && memberPubKey !== ourPubKey) {
-            ConversationController.getOrCreateAndWait(
-              memberPubKey,
-              'private'
-            ).then(() => {
-              textsecure.messaging.sendMessageToNumber(
-                memberPubKey,
-                '(If you see this message, you must be using an out-of-date client)',
-                [],
-                undefined,
-                [],
-                Date.now(),
-                undefined,
-                undefined,
-                { messageType: 'friend-request', sessionRequest: true }
+            if (nameChanged) {
+              window.log.warn(
+                'Non-admin attempts to change the name of the group'
               );
-            });
+            }
+
+            const membersMissing =
+              _.difference(
+                conversation.get('members'),
+                initialMessage.group.members
+              ).length > 0;
+
+            if (membersMissing) {
+              window.log.warn('Non-admin attempts to remove group members');
+            }
+
+            const messageAllowed = !nameChanged && !membersMissing;
+
+            if (!messageAllowed) {
+              confirm();
+              return null;
+            }
           }
-        });
+          // For every member, see if we need to establish a session:
+          initialMessage.group.members.forEach(memberPubKey => {
+            const haveSession = _.some(
+              textsecure.storage.protocol.sessions,
+              s => s.number === memberPubKey
+            );
+
+            const ourPubKey = textsecure.storage.user.getNumber();
+            if (!haveSession && memberPubKey !== ourPubKey) {
+              ConversationController.getOrCreateAndWait(
+                memberPubKey,
+                'private'
+              ).then(() => {
+                textsecure.messaging.sendMessageToNumber(
+                  memberPubKey,
+                  '(If you see this message, you must be using an out-of-date client)',
+                  [],
+                  undefined,
+                  [],
+                  Date.now(),
+                  undefined,
+                  undefined,
+                  { messageType: 'friend-request', sessionRequest: true }
+                );
+              });
+            }
+          });
+        } else if (newGroup) {
+          // We have an unknown group, we should request info
+          textsecure.messaging.requestGroupInfo(conversationId, [
+            primarySource,
+          ]);
+        }
       }
 
       const isSessionRequest =

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -1946,38 +1946,38 @@
             conversation.setFriendRequestStatus(
               window.friends.friendRequestStatusEnum.friends
             );
-          }
+          } else {
+            const fromAdmin = conversation
+              .get('groupAdmins')
+              .includes(primarySource);
 
-        const fromAdmin = conversation
-          .get('groupAdmins')
-          .includes(primarySource);
+            if (!fromAdmin) {
+              // Make sure the message is not removing members / renaming the group
+              const nameChanged =
+                conversation.get('name') !== initialMessage.group.name;
 
-          if (!fromAdmin) {
-            // Make sure the message is not removing members / renaming the group
-            const nameChanged =
-              conversation.get('name') !== initialMessage.group.name;
+              if (nameChanged) {
+                window.log.warn(
+                  'Non-admin attempts to change the name of the group'
+                );
+              }
 
-            if (nameChanged) {
-              window.log.warn(
-                'Non-admin attempts to change the name of the group'
-              );
-            }
+              const membersMissing =
+                _.difference(
+                  conversation.get('members'),
+                  initialMessage.group.members
+                ).length > 0;
 
-            const membersMissing =
-              _.difference(
-                conversation.get('members'),
-                initialMessage.group.members
-              ).length > 0;
+              if (membersMissing) {
+                window.log.warn('Non-admin attempts to remove group members');
+              }
 
-            if (membersMissing) {
-              window.log.warn('Non-admin attempts to remove group members');
-            }
+              const messageAllowed = !nameChanged && !membersMissing;
 
-            const messageAllowed = !nameChanged && !membersMissing;
-
-            if (!messageAllowed) {
-              confirm();
-              return null;
+              if (!messageAllowed) {
+                confirm();
+                return null;
+              }
             }
           }
           // For every member, see if we need to establish a session:

--- a/js/modules/loki_app_dot_net_api.js
+++ b/js/modules/loki_app_dot_net_api.js
@@ -229,7 +229,7 @@ class LokiAppDotNetServerAPI {
         window.storage.get('primaryDevicePubKey') ||
         textsecure.storage.user.getNumber();
       const profileConvo = ConversationController.get(ourNumber);
-      const profile = profileConvo.getLokiProfile();
+      const profile = profileConvo && profileConvo.getLokiProfile();
       const profileName = profile && profile.displayName;
       // if doesn't match, write it to the network
       if (tokenRes.response.data.user.name !== profileName) {

--- a/js/views/invite_friends_dialog_view.js
+++ b/js/views/invite_friends_dialog_view.js
@@ -74,7 +74,10 @@
             newMembers.length + existingMembers.length >
             window.CONSTANTS.SMALL_GROUP_SIZE_LIMIT
           ) {
-            const msg = window.i18n('maxGroupMembersError', window.CONSTANTS.SMALL_GROUP_SIZE_LIMIT);
+            const msg = window.i18n(
+              'maxGroupMembersError',
+              window.CONSTANTS.SMALL_GROUP_SIZE_LIMIT
+            );
 
             window.pushToast({
               title: msg,

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -152,6 +152,34 @@
     });
     return syncMessage;
   }
+  async function createGroupSyncProtoMessage(conversations) {
+    // We only want to sync across closed groups that we haven't left
+    const sessionGroups = conversations.filter(c => c.isClosedGroup() && !c.get('left') && c.isFriend());
+    const rawGroups = await Promise.all(
+      sessionGroups.map(async conversation => ({
+          id: conversation.id,
+          name: conversation.get('name'),
+          members: conversation.get('members') || [],
+          blocked: conversation.isBlocked(),
+          expireTimer: conversation.get('expireTimer'),
+          admins: conversation.get('groupAdmins') || [],
+        }))
+    );
+    // Convert raw groups to an array of buffers
+    const groupDetails = rawGroups
+      .map(x => new textsecure.protobuf.GroupDetails(x))
+      .map(x => x.encode());
+    // Serialise array of byteBuffers into 1 byteBuffer
+    const byteBuffer = serialiseByteBuffers(groupDetails);
+    const data = new Uint8Array(byteBuffer.toArrayBuffer());
+    const groups = new textsecure.protobuf.SyncMessage.Groups({
+      data,
+    });
+    const syncMessage = new textsecure.protobuf.SyncMessage({
+      groups,
+    });
+    return syncMessage;
+  }
   async function sendPairingAuthorisation(authorisation, recipientPubKey) {
     const pairingAuthorisation = createPairingAuthorisationProtoMessage(
       authorisation
@@ -222,5 +250,6 @@
     createPairingAuthorisationProtoMessage,
     sendUnpairingMessageToSecondary,
     createContactSyncProtoMessage,
+    createGroupSyncProtoMessage,
   };
 })();

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -154,16 +154,18 @@
   }
   async function createGroupSyncProtoMessage(conversations) {
     // We only want to sync across closed groups that we haven't left
-    const sessionGroups = conversations.filter(c => c.isClosedGroup() && !c.get('left') && c.isFriend());
+    const sessionGroups = conversations.filter(
+      c => c.isClosedGroup() && !c.get('left') && c.isFriend()
+    );
     const rawGroups = await Promise.all(
       sessionGroups.map(async conversation => ({
-          id: conversation.id,
-          name: conversation.get('name'),
-          members: conversation.get('members') || [],
-          blocked: conversation.isBlocked(),
-          expireTimer: conversation.get('expireTimer'),
-          admins: conversation.get('groupAdmins') || [],
-        }))
+        id: conversation.id,
+        name: conversation.get('name'),
+        members: conversation.get('members') || [],
+        blocked: conversation.isBlocked(),
+        expireTimer: conversation.get('expireTimer'),
+        admins: conversation.get('groupAdmins') || [],
+      }))
     );
     // Convert raw groups to an array of buffers
     const groupDetails = rawGroups

--- a/libloki/api.js
+++ b/libloki/api.js
@@ -109,8 +109,9 @@
   }
   async function createContactSyncProtoMessage(conversations) {
     // Extract required contacts information out of conversations
+    const sessionContacts = conversations.filter(c => c.isPrivate());
     const rawContacts = await Promise.all(
-      conversations.map(async conversation => {
+      sessionContacts.map(async conversation => {
         const profile = conversation.getLokiProfile();
         const number = conversation.getNumber();
         const name = profile

--- a/libloki/storage.js
+++ b/libloki/storage.js
@@ -131,7 +131,7 @@
     if (deviceMapping.isPrimary === '0') {
       const { primaryDevicePubKey } =
         authorisations.find(
-          authorisation => authorisation.secondaryDevicePubKey === pubKey
+          authorisation => authorisation && authorisation.secondaryDevicePubKey === pubKey
         ) || {};
       if (primaryDevicePubKey) {
         // do NOT call getprimaryDeviceMapping recursively

--- a/libloki/storage.js
+++ b/libloki/storage.js
@@ -131,7 +131,8 @@
     if (deviceMapping.isPrimary === '0') {
       const { primaryDevicePubKey } =
         authorisations.find(
-          authorisation => authorisation && authorisation.secondaryDevicePubKey === pubKey
+          authorisation =>
+            authorisation && authorisation.secondaryDevicePubKey === pubKey
         ) || {};
       if (primaryDevicePubKey) {
         // do NOT call getprimaryDeviceMapping recursively

--- a/libtextsecure/account_manager.js
+++ b/libtextsecure/account_manager.js
@@ -634,10 +634,10 @@
           blockSync: true,
         }
       );
-      // Send group sync message
-      await textsecure.messaging.sendGroupSyncMessage(
-        window.getConversations()
-      );
+      // Send sync messages
+      const conversations = window.getConversations().models;
+      textsecure.messaging.sendContactSyncMessage(conversations);
+      textsecure.messaging.sendGroupSyncMessage(conversations);
     },
     validatePubKeyHex(pubKey) {
       const c = new Whisper.Conversation({

--- a/libtextsecure/account_manager.js
+++ b/libtextsecure/account_manager.js
@@ -634,6 +634,8 @@
           blockSync: true,
         }
       );
+      // Send group sync message
+      await textsecure.messaging.sendGroupSyncMessage(window.getConversations())
     },
     validatePubKeyHex(pubKey) {
       const c = new Whisper.Conversation({

--- a/libtextsecure/account_manager.js
+++ b/libtextsecure/account_manager.js
@@ -635,7 +635,9 @@
         }
       );
       // Send group sync message
-      await textsecure.messaging.sendGroupSyncMessage(window.getConversations())
+      await textsecure.messaging.sendGroupSyncMessage(
+        window.getConversations()
+      );
     },
     validatePubKeyHex(pubKey) {
       const c = new Whisper.Conversation({

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1574,11 +1574,10 @@ MessageReceiver.prototype.extend({
   },
   handleGroups(envelope, groups) {
     window.log.info('group sync');
-    const { blob } = groups;
 
     // Note: we do not return here because we don't want to block the next message on
     //   this attachment download and a lot of processing of that attachment.
-    this.handleAttachment(blob).then(attachmentPointer => {
+    this.handleAttachment(groups).then(attachmentPointer => {
       const groupBuffer = new GroupBuffer(attachmentPointer.data);
       let groupDetails = groupBuffer.next();
       const promises = [];

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1475,7 +1475,11 @@ MessageReceiver.prototype.extend({
     const ourOtherDevices = await libloki.storage.getAllDevicePubKeysForPrimaryPubKey(
       window.storage.get('primaryDevicePubKey')
     );
-    const ourDevices = new Set([ourNumber, ourPrimaryNumber, ...ourOtherDevices]);
+    const ourDevices = new Set([
+      ourNumber,
+      ourPrimaryNumber,
+      ...ourOtherDevices,
+    ]);
     const validSyncSender = ourDevices.has(envelope.source);
     if (!validSyncSender) {
       throw new Error(

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1469,18 +1469,20 @@ MessageReceiver.prototype.extend({
     this.removeFromCache(envelope);
   },
   async handleSyncMessage(envelope, syncMessage) {
+    // We should only accept sync messages from our devices
     const ourNumber = textsecure.storage.user.getNumber();
-    // NOTE: Maybe we should be caching this list?
-    const ourDevices = await libloki.storage.getAllDevicePubKeysForPrimaryPubKey(
+    const ourPrimaryNumber = window.storage.get('primaryDevicePubKey');
+    const ourOtherDevices = await libloki.storage.getAllDevicePubKeysForPrimaryPubKey(
       window.storage.get('primaryDevicePubKey')
     );
-    const validSyncSender =
-      ourDevices && ourDevices.some(devicePubKey => devicePubKey === ourNumber);
+    const ourDevices = new Set([ourNumber, ourPrimaryNumber, ...ourOtherDevices]);
+    const validSyncSender = ourDevices.has(envelope.source);
     if (!validSyncSender) {
       throw new Error(
         "Received sync message from a device we aren't paired with"
       );
     }
+
     if (syncMessage.sent) {
       const sentMessage = syncMessage.sent;
       const to = sentMessage.message.group

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -1786,6 +1786,10 @@ MessageReceiver.prototype.extend({
           decrypted.group.members = [];
           decrypted.group.avatar = null;
           break;
+        case textsecure.protobuf.GroupContext.Type.REQUEST_INFO:
+          decrypted.body = null;
+          decrypted.attachments = [];
+          break;
         default:
           this.removeFromCache(envelope);
           throw new Error('Unknown group message type');

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -702,7 +702,9 @@ MessageSender.prototype = {
 
   async sendGroupSyncMessage(conversations) {
     const ourNumber = textsecure.storage.user.getNumber();
-    const syncMessage = await libloki.api.createGroupSyncProtoMessage(conversations);
+    const syncMessage = await libloki.api.createGroupSyncProtoMessage(
+      conversations
+    );
     const contentMessage = new textsecure.protobuf.Content();
     contentMessage.syncMessage = syncMessage;
 

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -700,6 +700,22 @@ MessageSender.prototype = {
     );
   },
 
+  async sendGroupSyncMessage(conversations) {
+    const ourNumber = textsecure.storage.user.getNumber();
+    const syncMessage = await libloki.api.createGroupSyncProtoMessage(conversations);
+    const contentMessage = new textsecure.protobuf.Content();
+    contentMessage.syncMessage = syncMessage;
+
+    const silent = true;
+    return this.sendIndividualProto(
+      ourNumber,
+      contentMessage,
+      Date.now(),
+      silent,
+      {} // options
+    );
+  },
+
   sendRequestContactSyncMessage(options) {
     const myNumber = textsecure.storage.user.getNumber();
     const myDevice = textsecure.storage.user.getDeviceId();

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -1107,7 +1107,7 @@ MessageSender.prototype = {
     return this.sendMessage(attrs, options);
   },
 
-  updateGroup(groupId, name, avatar, members, recipients, options) {
+  updateGroup(groupId, name, avatar, members, admins, recipients, options) {
     const proto = new textsecure.protobuf.DataMessage();
     proto.group = new textsecure.protobuf.GroupContext();
 
@@ -1162,6 +1162,14 @@ MessageSender.prototype = {
       proto.group.avatar = attachment;
       return this.sendGroupProto(groupNumbers, proto, Date.now(), options);
     });
+  },
+
+  requestGroupInfo(groupId, groupNumbers, options) {
+    const proto = new textsecure.protobuf.DataMessage();
+    proto.group = new textsecure.protobuf.GroupContext();
+    proto.group.id = stringToArrayBuffer(groupId);
+    proto.group.type = textsecure.protobuf.GroupContext.Type.REQUEST_INFO;
+    return this.sendGroupProto(groupNumbers, proto, Date.now(), options);
   },
 
   leaveGroup(groupId, groupNumbers, options) {
@@ -1263,6 +1271,7 @@ textsecure.MessageSender = function MessageSenderWrapper(username, password) {
   this.addNumberToGroup = sender.addNumberToGroup.bind(sender);
   this.setGroupName = sender.setGroupName.bind(sender);
   this.setGroupAvatar = sender.setGroupAvatar.bind(sender);
+  this.requestGroupInfo = sender.requestGroupInfo.bind(sender);
   this.leaveGroup = sender.leaveGroup.bind(sender);
   this.sendSyncMessage = sender.sendSyncMessage.bind(sender);
   this.getProfile = sender.getProfile.bind(sender);

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -282,6 +282,7 @@ message SyncMessage {
 
   message Groups {
     optional AttachmentPointer blob = 1;
+    optional bytes             data = 101;
   }
 
   message Blocked {
@@ -390,4 +391,5 @@ message GroupDetails {
   optional uint32 expireTimer = 6;
   optional string color       = 7;
   optional bool   blocked     = 8;
+  repeated string admins      = 9;
 }

--- a/ts/components/session/LeftPaneChannelSection.tsx
+++ b/ts/components/session/LeftPaneChannelSection.tsx
@@ -399,13 +399,18 @@ export class LeftPaneChannelSection extends React.Component<Props, State> {
     groupMembers: Array<ContactType>
   ) {
     // Validate groupName and groupMembers length
-    if (groupName.length === 0 ||
-      groupName.length > window.CONSTANTS.MAX_GROUP_NAME_LENGTH) {
-        window.pushToast({
-          title: window.i18n('invalidGroupName', window.CONSTANTS.MAX_GROUP_NAME_LENGTH),
-          type: 'error',
-          id: 'invalidGroupName',
-        });
+    if (
+      groupName.length === 0 ||
+      groupName.length > window.CONSTANTS.MAX_GROUP_NAME_LENGTH
+    ) {
+      window.pushToast({
+        title: window.i18n(
+          'invalidGroupName',
+          window.CONSTANTS.MAX_GROUP_NAME_LENGTH
+        ),
+        type: 'error',
+        id: 'invalidGroupName',
+      });
 
       return;
     }
@@ -416,7 +421,10 @@ export class LeftPaneChannelSection extends React.Component<Props, State> {
       groupMembers.length >= window.CONSTANTS.SMALL_GROUP_SIZE_LIMIT
     ) {
       window.pushToast({
-        title: window.i18n('invalidGroupSize', window.CONSTANTS.SMALL_GROUP_SIZE_LIMIT),
+        title: window.i18n(
+          'invalidGroupSize',
+          window.CONSTANTS.SMALL_GROUP_SIZE_LIMIT
+        ),
         type: 'error',
         id: 'invalidGroupSize',
       });


### PR DESCRIPTION
This PR adds the ability to sync across closed groups.

We also change the following:
- Send contact sync message separately from pairing accept message
- Send 3 contacts at a time during sync to avoid hitting storage server limit (This should be increased the next hardfork)

We also send 1 group per sync message but this should be increased after the next hardfork once the storage server file size limit increases