### PR TITLE
remove vh setting for friend-selection-list in _session.scss

### DIFF
--- a/stylesheets/_session.scss
+++ b/stylesheets/_session.scss
@@ -1422,9 +1422,9 @@ input {
   border: none;
 }
 
-.friend-selection-list {
-  width: 40vh;
-}
+// .friend-selection-list {
+//   width: 40vh;
+// }
 
 .session-beta-disclaimer {
   .session-modal {


### PR DESCRIPTION
A follow-up update to fix the position of the scrollbar that appears in windows of adding friends into a public chat group.

Solution: remove the vh setting for friend-selection-list in scss.

See original issue: 
https://github.com/loki-project/session-desktop/issues/832