### PR TITLE
Enable back notifications

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1470,7 +1470,8 @@
       serverTrustRoot: window.getServerTrustRoot(),
     };
 
-    Whisper.Notifications.disable(); // avoid notification flood until empty
+    // Whisper.Notifications.disable(); // avoid notification flood until empty
+    Whisper.Notifications.enable();
 
     if (Whisper.Registration.ongoingSecondaryDeviceRegistration()) {
       const ourKey = textsecure.storage.user.getNumber();
@@ -1642,7 +1643,7 @@
     //   scenarios where we're coming back from sleep, we can get offline/online events
     //   very fast, and it looks like a network blip. But we need to suppress
     //   notifications in these scenarios too. So we listen for 'reconnect' events.
-    Whisper.Notifications.disable();
+    // Whisper.Notifications.disable();
   }
   function onProgress(ev) {
     const { count } = ev;

--- a/js/background.js
+++ b/js/background.js
@@ -1470,8 +1470,10 @@
       serverTrustRoot: window.getServerTrustRoot(),
     };
 
-    // Whisper.Notifications.disable(); // avoid notification flood until empty
-    Whisper.Notifications.enable();
+    Whisper.Notifications.disable(); // avoid notification flood until empty
+    setTimeout(() => {
+      Whisper.Notifications.enable();
+    }, window.CONSTANTS.NOTIFICATION_ENABLE_TIMEOUT_SECONDS * 1000);
 
     if (Whisper.Registration.ongoingSecondaryDeviceRegistration()) {
       const ourKey = textsecure.storage.user.getNumber();
@@ -1643,7 +1645,12 @@
     //   scenarios where we're coming back from sleep, we can get offline/online events
     //   very fast, and it looks like a network blip. But we need to suppress
     //   notifications in these scenarios too. So we listen for 'reconnect' events.
-    // Whisper.Notifications.disable();
+    Whisper.Notifications.disable();
+
+    // Enable back notifications once most messages have been fetched
+    setTimeout(() => {
+      Whisper.Notifications.enable();
+    }, window.CONSTANTS.NOTIFICATION_ENABLE_TIMEOUT_SECONDS * 1000);
   }
   function onProgress(ev) {
     const { count } = ev;

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -34,8 +34,6 @@
   Whisper.Notifications = new (Backbone.Collection.extend({
     initialize() {
       this.isEnabled = false;
-      this.on('add', this.update);
-      this.on('remove', this.onRemove);
 
       this.lastNotification = null;
 
@@ -45,7 +43,11 @@
       //   and batches up the quick successive update() calls we get from an incoming
       //   read sync, which might have a number of messages referenced inside of it.
       this.fastUpdate = this.update;
-      this.update = _.debounce(this.update, 1000);
+      this.update = _.debounce(this.update, 2000);
+
+      // make those calls use the debounced function
+      this.on('add', this.update);
+      this.on('remove', this.onRemove);
     },
     update() {
       if (this.lastNotification) {

--- a/preload.js
+++ b/preload.js
@@ -70,6 +70,7 @@ window.CONSTANTS = {
   MAX_MESSAGE_BODY_LENGTH: 64 * 1024,
   // Limited due to the proof-of-work requirement
   SMALL_GROUP_SIZE_LIMIT: 10,
+  NOTIFICATION_ENABLE_TIMEOUT_SECONDS: 10, // number of seconds to turn on notifications after reconnect/start of app
 };
 
 window.versionInfo = {


### PR DESCRIPTION
Signal disables notification on start of app to avoid flooding the user with "new message" notifications.
It waits for the server to send a "end of messages" (`/api/v1/queue/empty`) to turn them back.

As we do not have a way to do the same, I just enabled notifications at the start. The inconvenient is it will flood the user on app start/reconnect from network loss.

