### PR TITLE
Move cleanupOrphanedAttachments before restart

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -398,19 +398,15 @@
     await storage.put('version', currentVersion);
 
     if (newVersion) {
-      await window.Signal.Data.cleanupOrphanedAttachments();
-
       window.log.info(
         `New version detected: ${currentVersion}; previous: ${lastVersion}`
       );
 
-      if (
-        lastVersion &&
-        window.isBeforeVersion(lastVersion, 'v1.15.0-beta.5')
-      ) {
-        await window.Signal.Logs.deleteAll();
-        window.restart();
-      }
+      await window.Signal.Data.cleanupOrphanedAttachments();
+
+      await window.Signal.Logs.deleteAll();
+
+      window.restart();
     }
 
     if (isIndexedDBPresent) {

--- a/js/background.js
+++ b/js/background.js
@@ -398,7 +398,6 @@
     await storage.put('version', currentVersion);
 
     if (newVersion) {
-
       await window.Signal.Data.cleanupOrphanedAttachments();
 
       window.log.info(

--- a/js/background.js
+++ b/js/background.js
@@ -398,6 +398,13 @@
     await storage.put('version', currentVersion);
 
     if (newVersion) {
+
+      await window.Signal.Data.cleanupOrphanedAttachments();
+
+      window.log.info(
+        `New version detected: ${currentVersion}; previous: ${lastVersion}`
+      );
+
       if (
         lastVersion &&
         window.isBeforeVersion(lastVersion, 'v1.15.0-beta.5')
@@ -405,10 +412,6 @@
         await window.Signal.Logs.deleteAll();
         window.restart();
       }
-
-      window.log.info(
-        `New version detected: ${currentVersion}; previous: ${lastVersion}`
-      );
     }
 
     if (isIndexedDBPresent) {
@@ -430,10 +433,6 @@
     }
 
     Views.Initialization.setMessage(window.i18n('optimizingApplication'));
-
-    if (newVersion) {
-      await window.Signal.Data.cleanupOrphanedAttachments();
-    }
 
     Views.Initialization.setMessage(window.i18n('loading'));
 

--- a/js/background.js
+++ b/js/background.js
@@ -405,8 +405,6 @@
       await window.Signal.Data.cleanupOrphanedAttachments();
 
       await window.Signal.Logs.deleteAll();
-
-      window.restart();
     }
 
     if (isIndexedDBPresent) {


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/development) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

Fixes #893 

The Problem was that a restart was called before cleanupOrphanedAttachments gets called. So cleanupOrphanedAttachments tries to interact with a database, which is already closed. This causes the `Error: Object has been destroyed`-Error.

OS: Windows 10 Pro Insider Preview
