### PR TITLE
Fix #952: remove org.whispersystems in notifications

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,7 +27,7 @@ const {
   shell,
 } = electron;
 
-const appUserModelId = `org.whispersystems.${packageJson.name}`;
+const appUserModelId = packageJson.build.appId;
 console.log('Set Windows Application User Model ID (AUMID)', {
   appUserModelId,
 });


### PR DESCRIPTION
remove org.whispersystems from notifications to match package.json build appId, fixes #952

I still have some additional recommendations in #952 that I can append to this PR if approved.