### PR TITLE
make session "work" with .loki tld

### DIFF
--- a/js/modules/loki_public_chat_api.js
+++ b/js/modules/loki_public_chat_api.js
@@ -29,11 +29,11 @@ class LokiPublicChatFactoryAPI extends EventEmitter {
     try {
       // allow .loki (may only need an agent but not sure
       //              until we have a .loki to test with)
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = serverUrl.match(/\.loki\//)
-        ? 0
-        : 1;
+      if (serverUrl.match(/\.loki$/)) {
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+      }
       await nodeFetch(serverUrl);
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = 1;
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1';
       // const txt = await res.text();
     } catch (e) {
       process.env.NODE_TLS_REJECT_UNAUTHORIZED = 1;


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

* [x] I have read the [README](https://github.com/loki-project/loki-messenger/blob/master/README.md) and [Contributor Guidelines](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md)

### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/development) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/loki-project/loki-messenger/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

setting `process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;` is different from setting `process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';` because javascript.

please note that this isn't the correct fix for this code it just makes it "work".


