### PR TITLE
Add overflow-y auto to session-id-editable

### DIFF
--- a/stylesheets/_session.scss
+++ b/stylesheets/_session.scss
@@ -1457,6 +1457,7 @@ label {
   resize: none;
   overflow: hidden;
   user-select: all;
+  overflow-y: auto;
 }
 
 input {


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/development) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description
Fixes #968
Add overflow-y auto to session-id-editable so you can see the whole session id.