### PR TITLE
Enable building win32 binaries.

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,13 @@
       "verifyUpdateCodeSignature": false,
       "icon": "build/icons/win/icon.ico",
       "target": [
-        "nsis"
+        {
+          "target": "nsis",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        }
       ]
     },
     "nsis": {


### PR DESCRIPTION
> If you build both ia32 and x64 arch (--x64 --ia32), you in any case get one installer. Appropriate arch will be installed automatically.