### PR TITLE
Revert "Enable building win32 binaries."

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,13 +235,7 @@
       "verifyUpdateCodeSignature": false,
       "icon": "build/icons/win/icon.ico",
       "target": [
-        {
-          "target": "nsis",
-          "arch": [
-            "x64",
-            "ia32"
-          ]
-        }
+        "nsis"
       ]
     },
     "nsis": {


### PR DESCRIPTION
Reverts loki-project/session-desktop#980

This makes the installer fail on 64bit machines and increases the installer size unnecessarily 