### PR TITLE
Toast on device pairing request received but in device pairing mode

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -987,6 +987,13 @@
   "devicePairingReceived": {
     "message": "Device Pairing Received"
   },
+  "devicePairingRequestReceivedNoListenerTitle": {
+    "message": "Device pairing request received."
+  },
+  "devicePairingRequestReceivedNoListenerDescription": {
+    "message":
+      "Device pairing request received but you are not on the device pairing screen. \nFirst go to Settings -> Device -> Link New Device."
+  },
   "waitingForDeviceToRegister": {
     "message": "Waiting for device to register..."
   },

--- a/js/background.js
+++ b/js/background.js
@@ -1340,6 +1340,18 @@
       }
     });
 
+    Whisper.events.on('devicePairingRequestReceivedNoListener', async () => {
+      window.pushToast({
+        title: window.i18n('devicePairingRequestReceivedNoListenerTitle'),
+        description: window.i18n(
+          'devicePairingRequestReceivedNoListenerDescription'
+        ),
+        type: 'info',
+        id: 'pairingRequestNoListener',
+        shouldFade: false,
+      });
+    });
+
     Whisper.events.on('devicePairingRequestAccepted', async (pubKey, cb) => {
       try {
         await getAccountManager().authoriseSecondaryDevice(pubKey);

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -977,6 +977,11 @@ MessageReceiver.prototype.extend({
           'devicePairingRequestReceived',
           pairingRequest.secondaryDevicePubKey
         );
+      } else {
+        Whisper.events.trigger(
+          'devicePairingRequestReceivedNoListener',
+          pairingRequest.secondaryDevicePubKey
+        );
       }
       // Ignore requests if the dialog is closed
     }


### PR DESCRIPTION
Showing a toast which does not fade until closed so the user can read the manual to open the device pairing dialog