### PR TITLE
Client-side implementation for onion requests

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -993,7 +993,6 @@ async function updateToLokiSchemaVersion3(currentVersion, instance) {
   console.log('updateToLokiSchemaVersion3: starting...');
   await instance.run('BEGIN TRANSACTION;');
 
-
   await instance.run(
     `INSERT INTO loki_schema (
         version
@@ -1505,7 +1504,6 @@ async function getSecondaryDevicesFor(primaryDevicePubKey) {
 }
 
 async function getGuardNodes() {
-
   const nodes = await db.all(`SELECT ed25519PubKey FROM ${GUARD_NODE_TABLE};`);
 
   if (!nodes) {
@@ -1513,55 +1511,27 @@ async function getGuardNodes() {
   }
 
   return nodes;
-
-}
-
-async function createOrUpdatePreKey(data) {
-  const { id, recipient } = data;
-  if (!id) {
-    throw new Error('createOrUpdate: Provided data did not have a truthy id');
-  }
-
-  await db.run(
-    `INSERT OR REPLACE INTO ${PRE_KEYS_TABLE} (
-      id,
-      recipient,
-      json
-    ) values (
-      $id,
-      $recipient,
-      $json
-    )`,
-    {
-      $id: id,
-      $recipient: recipient || '',
-      $json: objectToJSON(data),
-    }
-  );
 }
 
 async function updateGuardNodes(nodes) {
-
   await db.run('BEGIN TRANSACTION;');
 
   await db.run(`DELETE FROM ${GUARD_NODE_TABLE}`);
 
-  await Promise.all(nodes.map(edkey => 
-
-    db.run(
-      `INSERT INTO ${GUARD_NODE_TABLE} (
+  await Promise.all(
+    nodes.map(edkey =>
+      db.run(
+        `INSERT INTO ${GUARD_NODE_TABLE} (
         ed25519PubKey
       ) values ($ed25519PubKey)`,
-      {
-        $ed25519PubKey: edkey,
-      }
+        {
+          $ed25519PubKey: edkey,
+        }
+      )
     )
-
-  ));
+  );
 
   await db.run('END TRANSACTION;');
-
-
 }
 
 async function getPrimaryDeviceFor(secondaryDevicePubKey) {

--- a/app/sql.js
+++ b/app/sql.js
@@ -98,6 +98,8 @@ module.exports = {
   getAllSessions,
 
   getSwarmNodesByPubkey,
+  getGuardNodes,
+  updateGuardNodes,
 
   getConversationCount,
   saveConversation,
@@ -807,6 +809,7 @@ async function updateSchema(instance) {
 const LOKI_SCHEMA_VERSIONS = [
   updateToLokiSchemaVersion1,
   updateToLokiSchemaVersion2,
+  updateToLokiSchemaVersion3,
 ];
 
 async function updateToLokiSchemaVersion1(currentVersion, instance) {
@@ -973,6 +976,34 @@ async function updateToLokiSchemaVersion2(currentVersion, instance) {
   );
   await instance.run('COMMIT TRANSACTION;');
   console.log('updateToLokiSchemaVersion2: success!');
+}
+
+async function updateToLokiSchemaVersion3(currentVersion, instance) {
+  if (currentVersion >= 3) {
+    return;
+  }
+
+  await instance.run(
+    `CREATE TABLE ${GUARD_NODE_TABLE}(
+      id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+      ed25519PubKey VARCHAR(64)
+    );`
+  );
+
+  console.log('updateToLokiSchemaVersion3: starting...');
+  await instance.run('BEGIN TRANSACTION;');
+
+
+  await instance.run(
+    `INSERT INTO loki_schema (
+        version
+      ) values (
+        3
+      );`
+  );
+
+  await instance.run('COMMIT TRANSACTION;');
+  console.log('updateToLokiSchemaVersion3: success!');
 }
 
 async function updateLokiSchema(instance) {
@@ -1400,6 +1431,9 @@ async function removeAllSignedPreKeys() {
 }
 
 const PAIRING_AUTHORISATIONS_TABLE = 'pairingAuthorisations';
+
+const GUARD_NODE_TABLE = 'guardNodes';
+
 async function getAuthorisationForSecondaryPubKey(pubKey, options) {
   const granted = options && options.granted;
   let filter = '';
@@ -1468,6 +1502,66 @@ async function getSecondaryDevicesFor(primaryDevicePubKey) {
     primaryDevicePubKey
   );
   return map(authorisations, row => row.secondaryDevicePubKey);
+}
+
+async function getGuardNodes() {
+
+  const nodes = await db.all(`SELECT ed25519PubKey FROM ${GUARD_NODE_TABLE};`);
+
+  if (!nodes) {
+    return null;
+  }
+
+  return nodes;
+
+}
+
+async function createOrUpdatePreKey(data) {
+  const { id, recipient } = data;
+  if (!id) {
+    throw new Error('createOrUpdate: Provided data did not have a truthy id');
+  }
+
+  await db.run(
+    `INSERT OR REPLACE INTO ${PRE_KEYS_TABLE} (
+      id,
+      recipient,
+      json
+    ) values (
+      $id,
+      $recipient,
+      $json
+    )`,
+    {
+      $id: id,
+      $recipient: recipient || '',
+      $json: objectToJSON(data),
+    }
+  );
+}
+
+async function updateGuardNodes(nodes) {
+
+  await db.run('BEGIN TRANSACTION;');
+
+  await db.run(`DELETE FROM ${GUARD_NODE_TABLE}`);
+
+  await Promise.all(nodes.map(edkey => 
+
+    db.run(
+      `INSERT INTO ${GUARD_NODE_TABLE} (
+        ed25519PubKey
+      ) values ($ed25519PubKey)`,
+      {
+        $ed25519PubKey: edkey,
+      }
+    )
+
+  ));
+
+  await db.run('END TRANSACTION;');
+
+
 }
 
 async function getPrimaryDeviceFor(secondaryDevicePubKey) {

--- a/js/background.js
+++ b/js/background.js
@@ -1428,6 +1428,9 @@
   async function connect(firstRun) {
     window.log.info('connect');
 
+    // Initialize paths for onion requests
+    await window.lokiSnodeAPI.buildNewOnionPaths();
+
     // Bootstrap our online/offline detection, only the first time we connect
     if (connectCount === 0 && navigator.onLine) {
       window.addEventListener('offline', onOffline);

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -101,6 +101,9 @@ module.exports = {
   getPrimaryDeviceFor,
   getPairedDevicesFor,
 
+  getGuardNodes,
+  updateGuardNodes,
+
   createOrUpdateItem,
   getItemById,
   getAllItems,
@@ -117,6 +120,7 @@ module.exports = {
   removeAllSessions,
   getAllSessions,
 
+  // Doesn't look like this is used at all
   getSwarmNodesByPubkey,
 
   getConversationCount,
@@ -645,6 +649,14 @@ function getAuthorisationForSecondaryPubKey(pubKey) {
 
 function getSecondaryDevicesFor(primaryDevicePubKey) {
   return channels.getSecondaryDevicesFor(primaryDevicePubKey);
+}
+
+function getGuardNodes() {
+  return channels.getGuardNodes();
+}
+
+function updateGuardNodes(nodes) {
+  return channels.updateGuardNodes(nodes);
 }
 
 function getPrimaryDeviceFor(secondaryDevicePubKey) {

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -283,7 +283,6 @@ class LokiMessageAPI {
         !stopPollingResult &&
         successiveFailures < MAX_ACCEPTABLE_FAILURES
       ) {
-        await sleepFor(successiveFailures * 1000);
 
         // TODO: Revert back to using snode address instead of IP
         try {
@@ -337,6 +336,10 @@ class LokiMessageAPI {
           }
           successiveFailures += 1;
         }
+
+        // Always wait a bit as we are no longer long-polling
+        await sleepFor(Math.max(successiveFailures, 2) * 1000);
+
       }
       if (successiveFailures >= MAX_ACCEPTABLE_FAILURES) {
         const remainingSwarmSnodes = await lokiSnodeAPI.unreachableNode(
@@ -374,9 +377,6 @@ class LokiMessageAPI {
     const options = {
       timeout: 40000,
       ourPubKey: this.ourKey,
-      headers: {
-        [LOKI_LONGPOLL_HEADER]: true,
-      },
     };
 
     // let exceptions bubble up

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -7,7 +7,6 @@ const { lokiRpc } = require('./loki_rpc');
 
 const DEFAULT_CONNECTIONS = 3;
 const MAX_ACCEPTABLE_FAILURES = 1;
-const LOKI_LONGPOLL_HEADER = 'X-Loki-Long-Poll';
 
 function sleepFor(time) {
   return new Promise(resolve => {
@@ -283,7 +282,6 @@ class LokiMessageAPI {
         !stopPollingResult &&
         successiveFailures < MAX_ACCEPTABLE_FAILURES
       ) {
-
         // TODO: Revert back to using snode address instead of IP
         try {
           // in general, I think we want exceptions to bubble up
@@ -339,7 +337,6 @@ class LokiMessageAPI {
 
         // Always wait a bit as we are no longer long-polling
         await sleepFor(Math.max(successiveFailures, 2) * 1000);
-
       }
       if (successiveFailures >= MAX_ACCEPTABLE_FAILURES) {
         const remainingSwarmSnodes = await lokiSnodeAPI.unreachableNode(

--- a/js/modules/loki_rpc.js
+++ b/js/modules/loki_rpc.js
@@ -116,9 +116,9 @@ const sendOnionRequest = async (req_idx, nodePath, targetNode, plaintext) => {
   const url = `https://${nodePath[0].ip}:${nodePath[0].port}/onion_req`;
 
   // we only proxy to snodes...
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
   const response = await nodeFetch(url, fetchOptions);
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 1;
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1';
 
   return await processOnionResponse(req_idx, response, ctx_1.symmetricKey, true);
 }

--- a/js/modules/loki_rpc.js
+++ b/js/modules/loki_rpc.js
@@ -12,6 +12,10 @@ const snodeHttpsAgent = new https.Agent({
 const LOKI_EPHEMKEY_HEADER = 'X-Loki-EphemKey';
 const endpointBase = '/storage_rpc/v1';
 
+
+// Request index for debugging
+let onion_req_idx = 0;
+
 const decryptResponse = async (response, address) => {
   let plaintext = false;
   try {
@@ -31,8 +35,209 @@ const decryptResponse = async (response, address) => {
 
 const timeoutDelay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
+const encryptForNode = async (node, payload) => {
+
+  const textEncoder = new TextEncoder();
+  const plaintext = textEncoder.encode(payload);
+
+  const ephemeral = libloki.crypto.generateEphemeralKeyPair();
+
+  const snPubkey = StringView.hexToArrayBuffer(node.pubkey_x25519);
+
+  const ephemeralSecret = libsignal.Curve.calculateAgreement(
+    snPubkey,
+    ephemeral.privKey
+  );
+
+  const salt = window.Signal.Crypto.bytesFromString("LOKI");
+
+  let key = await crypto.subtle.importKey('raw', salt, {name: 'HMAC', hash: {name: 'SHA-256'}}, false, ['sign']);
+  let symmetricKey = await crypto.subtle.sign( {name: 'HMAC', hash: 'SHA-256'}, key, ephemeralSecret);
+
+  const ciphertext = await window.libloki.crypto.EncryptGCM(
+    symmetricKey,
+    plaintext
+  );
+
+  return {ciphertext, symmetricKey, "ephemeral_key": ephemeral.pubKey};
+
+}
+
+// Returns the actual ciphertext, symmetric key that will be used
+// for decryption, and an ephemeral_key to send to the next hop
+const encryptForDestination = async (node, payload) => {
+  // Do we still need "headers"?
+  const req_str = JSON.stringify({"body": payload, "headers": ""});
+
+  return await encryptForNode(node, req_str);
+}
+
+// `ctx` holds info used by `node` to relay further
+const encryptForRelay = async (node, next_node, ctx) => {
+
+  const payload = ctx.ciphertext;
+
+  const req_json = {
+    "ciphertext": dcodeIO.ByteBuffer.wrap(payload).toString('base64'),
+    "ephemeral_key": StringView.arrayBufferToHex(ctx.ephemeral_key),
+    "destination": next_node.pubkey_ed25519,
+  }
+
+  const req_str = JSON.stringify(req_json);
+
+  return await encryptForNode(node, req_str);
+
+}
+
+const BAD_PATH = "bad_path";
+
+// May return false BAD_PATH, indicating that we should try a new 
+const sendOnionRequest = async (req_idx, nodePath, targetNode, plaintext) => {
+
+  log.info("Sending an onion request");
+
+  let ctx_1 = await encryptForDestination(targetNode, plaintext);
+  let ctx_2 = await encryptForRelay(nodePath[2], targetNode, ctx_1);
+  let ctx_3 = await encryptForRelay(nodePath[1], nodePath[2], ctx_2);
+  let ctx_4 = await encryptForRelay(nodePath[0], nodePath[1], ctx_3);
+
+  const ciphertext_base64 = dcodeIO.ByteBuffer.wrap(ctx_4.ciphertext).toString('base64');
+
+  const payload = {
+    "ciphertext": ciphertext_base64,
+    "ephemeral_key": StringView.arrayBufferToHex(ctx_4.ephemeral_key),
+  }
+
+  const fetchOptions = {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  };
+
+  const url = `https://${nodePath[0].ip}:${nodePath[0].port}/onion_req`;
+
+  // we only proxy to snodes...
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+  const response = await nodeFetch(url, fetchOptions);
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = 1;
+
+  return await processOnionResponse(req_idx, response, ctx_1.symmetricKey, true);
+}
+
+// Process a response as it arrives from `nodeFetch`, handling
+// http errors and attempting to decrypt the body with `shared_key`
+const processOnionResponse = async (req_idx, response, shared_key, use_aes_gcm) => {
+
+  console.log(`(${req_idx}) [path] processing onion response`);
+
+  // detect SNode is not ready (not in swarm; not done syncing)
+  if (response.status === 503) {
+    console.warn("Got 503: snode not ready");
+
+    return BAD_PATH;
+  }
+
+  if (response.status == 504) {
+    log.warn('Got 504: Gateway timeout');
+    return BAD_PATH;
+  }
+
+  if (response.status == 404) {
+    // Why would we get this error on testnet?
+    log.warn('Got 404: Gateway timeout');
+    return BAD_PATH;
+  }
+
+  if (response.status !== 200) {
+    log.warn('lokiRpc sendToProxy fetch unhandled error code:', response.status);
+    return;
+  }
+  
+  const ciphertext = await response.text();
+  if (!ciphertext) {
+    log.warn("[path]: Target node return empty ciphertext");
+    return;
+  }
+
+  let plaintext;
+  let ciphertextBuffer;
+  try {
+    ciphertextBuffer = dcodeIO.ByteBuffer.wrap(
+      ciphertext,
+      'base64'
+    ).toArrayBuffer();
+
+    const decrypt_fn = use_aes_gcm ? window.libloki.crypto.DecryptGCM : window.libloki.crypto.DHDecrypt;
+
+    const plaintextBuffer = await decrypt_fn(
+      shared_key,
+      ciphertextBuffer
+    );
+
+    const textDecoder = new TextDecoder();
+    plaintext = textDecoder.decode(plaintextBuffer);
+  } catch(e) {
+    log.error(
+      'lokiRpc sendToProxy decode error',
+      e.code,
+      e.message,
+      `from ${randSnode.ip}:${randSnode.port} ciphertext:`,
+      ciphertext
+    );
+    if (ciphertextBuffer) {
+      log.error('ciphertextBuffer', ciphertextBuffer);
+    }
+    return;
+  }
+
+  try {
+    const jsonRes = JSON.parse(plaintext);
+    // emulate nodeFetch response...
+    jsonRes.json = () => {
+      try {
+        let res = JSON.parse(jsonRes.body);
+        return res;
+      } catch (e) {
+        log.error(
+          'lokiRpc sendToProxy parse error',
+          e.code,
+          e.message,
+          `from ${randSnode.ip}:${randSnode.port} json:`,
+          jsonRes.body
+        );
+      }
+      return false;
+    };
+    return jsonRes;
+  } catch (e) {
+    log.error(
+      'lokiRpc sendToProxy parse error',
+      e.code,
+      e.message,
+      `from ${randSnode.ip}:${randSnode.port} json:`,
+      plaintext
+    );
+
+    return;
+  }
+
+}
+
 const sendToProxy = async (options = {}, targetNode, retryNumber = 0) => {
-  const randSnode = await lokiSnodeAPI.getRandomSnodeAddress();
+
+  let snodePool = await lokiSnodeAPI.getRandomSnodePool();
+
+  if (snodePool.length < 2) {
+    console.error("Not enough service nodes for a proxy request, only have: ", snodePool.length);
+    return;
+  }
+
+  // Making sure the proxy node is not the same as the target node:
+  const snodePoolSafe = _.without(
+    snodePool,
+    _.find(snodePool, { pubkey_ed25519: targetNode.pubkey_ed25519 })
+  );
+
+  const randSnode = window.Lodash.sample(snodePoolSafe);
 
   // Don't allow arbitrary URLs, only snodes and loki servers
   const url = `https://${randSnode.ip}:${randSnode.port}/proxy`;
@@ -262,6 +467,34 @@ const lokiFetch = async (url, options = {}, targetNode = null) => {
   };
 
   try {
+
+    // Absence of targetNode indicates that we want a direct connection
+    // (e.g. to connect to a seed node for the first time)
+    if (window.lokiFeatureFlags.useOnionRequests && targetNode) {
+
+      // Loop until the result is not BAD_PATH
+      while (true) {
+
+        // Get a path excluding `targetNode`:
+        const path = await lokiSnodeAPI.getOnionPath(targetNode);
+        const this_idx = onion_req_idx++;
+  
+        log.info(`(${this_idx}) using path ${path[0].ip}:${path[0].port} -> ${path[1].ip}:${path[1].port} -> ${path[2].ip}:${path[2].port} => ${targetNode.ip}:${targetNode.port}`);
+  
+        const result = await sendOnionRequest(this_idx, path, targetNode, fetchOptions.body);
+  
+        if (result == BAD_PATH) {
+          log.error("[path] Error on the path");
+          lokiSnodeAPI.markPathAsBad(path);
+        } else {
+          return result ? result.json() : false;
+        }
+
+      }
+
+    }
+
+
     if (window.lokiFeatureFlags.useSnodeProxy && targetNode) {
       const result = await sendToProxy(fetchOptions, targetNode);
       // if not result, maybe we should throw??
@@ -332,6 +565,7 @@ const lokiFetch = async (url, options = {}, targetNode = null) => {
 };
 
 // Wrapper for a JSON RPC request
+// Annoyngly, this is used for Lokid requests too
 const lokiRpc = (
   address,
   port,

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -160,7 +160,7 @@ class LokiSnodeAPI {
 
     if (otherPaths.length === 0) {
       // This should never happen!
-      log.error('No onion paths available after filtering');
+      throw new Error('No onion paths available after filtering');
     }
 
     return otherPaths[0].path;

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -240,8 +240,10 @@ class LokiSnodeAPI {
         let timeoutTimer = null;
         // private retry container
         const trySeedNode = async (consecutiveErrors = 0) => {
+
+          // Removed limit until there is a way to get snode info
+          // for individual nodes (needed for guard nodes)
           const params = {
-            limit: RANDOM_SNODES_POOL_SIZE,
             active_only: true,
             fields: {
               public_ip: true,

--- a/libloki/crypto.js
+++ b/libloki/crypto.js
@@ -17,6 +17,7 @@
   class FallBackDecryptionError extends Error {}
 
   const IV_LENGTH = 16;
+  const NONCE_LENGTH = 12;
 
   async function DHEncrypt(symmetricKey, plainText) {
     const iv = libsignal.crypto.getRandomBytes(IV_LENGTH);
@@ -31,6 +32,35 @@
     ivAndCiphertext.set(new Uint8Array(iv));
     ivAndCiphertext.set(new Uint8Array(ciphertext), iv.byteLength);
     return ivAndCiphertext;
+  }
+
+  async function EncryptGCM(symmetricKey, plaintext) {
+
+    const nonce = crypto.getRandomValues(new Uint8Array(NONCE_LENGTH));
+
+    const key = await crypto.subtle.importKey('raw', symmetricKey, {name: 'AES-GCM'}, false, ['encrypt']);
+
+    const ciphertext = await crypto.subtle.encrypt({name: 'AES-GCM', iv: nonce, tagLength: 128}, key, plaintext);
+
+    const ivAndCiphertext = new Uint8Array(
+      NONCE_LENGTH + ciphertext.byteLength
+    );
+
+    ivAndCiphertext.set(nonce);
+    ivAndCiphertext.set(new Uint8Array(ciphertext), nonce.byteLength);
+
+    return ivAndCiphertext;
+  }
+
+  async function DecryptGCM(symmetricKey, ivAndCiphertext) {
+
+      const nonce = ivAndCiphertext.slice(0, NONCE_LENGTH);
+      const ciphertext = ivAndCiphertext.slice(NONCE_LENGTH);
+
+      const key = await crypto.subtle.importKey('raw', symmetricKey, {name: 'AES-GCM'}, false, ['decrypt']);
+
+      return await crypto.subtle.decrypt({name: 'AES-GCM', iv: nonce}, key, ciphertext);
+
   }
 
   async function DHDecrypt(symmetricKey, ivAndCiphertext) {
@@ -106,11 +136,17 @@
     return Multibase.decode(`${base32zCode}${snodeAddressClean}`);
   }
 
+  function generateEphemeralKeyPair() {
+    let keys = libsignal.Curve.generateKeyPair();
+    // Signal protocol prepends with "0x05"
+    keys.pubKey = keys.pubKey.slice(1);
+    return keys;
+  }
+
   class LokiSnodeChannel {
     constructor() {
-      this._ephemeralKeyPair = libsignal.Curve.generateKeyPair();
-      // Signal protocol prepends with "0x05"
-      this._ephemeralKeyPair.pubKey = this._ephemeralKeyPair.pubKey.slice(1);
+
+      this._ephemeralKeyPair = generateEphemeralKeyPair();
       this._ephemeralPubKeyHex = StringView.arrayBufferToHex(
         this._ephemeralKeyPair.pubKey
       );
@@ -474,7 +510,9 @@
 
   window.libloki.crypto = {
     DHEncrypt,
+    EncryptGCM, // AES-GCM
     DHDecrypt,
+    DecryptGCM, // AES-GCM
     FallBackSessionCipher,
     FallBackDecryptionError,
     snodeCipher,
@@ -485,6 +523,7 @@
     validateAuthorisation,
     PairingType,
     LokiSessionCipher,
+    generateEphemeralKeyPair,
     // for testing
     _LokiSnodeChannel: LokiSnodeChannel,
     _decodeSnodeAddressToPubKey: decodeSnodeAddressToPubKey,

--- a/libloki/crypto.js
+++ b/libloki/crypto.js
@@ -35,12 +35,21 @@
   }
 
   async function EncryptGCM(symmetricKey, plaintext) {
-
     const nonce = crypto.getRandomValues(new Uint8Array(NONCE_LENGTH));
 
-    const key = await crypto.subtle.importKey('raw', symmetricKey, {name: 'AES-GCM'}, false, ['encrypt']);
+    const key = await crypto.subtle.importKey(
+      'raw',
+      symmetricKey,
+      { name: 'AES-GCM' },
+      false,
+      ['encrypt']
+    );
 
-    const ciphertext = await crypto.subtle.encrypt({name: 'AES-GCM', iv: nonce, tagLength: 128}, key, plaintext);
+    const ciphertext = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv: nonce, tagLength: 128 },
+      key,
+      plaintext
+    );
 
     const ivAndCiphertext = new Uint8Array(
       NONCE_LENGTH + ciphertext.byteLength
@@ -53,14 +62,22 @@
   }
 
   async function DecryptGCM(symmetricKey, ivAndCiphertext) {
+    const nonce = ivAndCiphertext.slice(0, NONCE_LENGTH);
+    const ciphertext = ivAndCiphertext.slice(NONCE_LENGTH);
 
-      const nonce = ivAndCiphertext.slice(0, NONCE_LENGTH);
-      const ciphertext = ivAndCiphertext.slice(NONCE_LENGTH);
+    const key = await crypto.subtle.importKey(
+      'raw',
+      symmetricKey,
+      { name: 'AES-GCM' },
+      false,
+      ['decrypt']
+    );
 
-      const key = await crypto.subtle.importKey('raw', symmetricKey, {name: 'AES-GCM'}, false, ['decrypt']);
-
-      return await crypto.subtle.decrypt({name: 'AES-GCM', iv: nonce}, key, ciphertext);
-
+    return crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: nonce },
+      key,
+      ciphertext
+    );
   }
 
   async function DHDecrypt(symmetricKey, ivAndCiphertext) {
@@ -137,7 +154,7 @@
   }
 
   function generateEphemeralKeyPair() {
-    let keys = libsignal.Curve.generateKeyPair();
+    const keys = libsignal.Curve.generateKeyPair();
     // Signal protocol prepends with "0x05"
     keys.pubKey = keys.pubKey.slice(1);
     return keys;
@@ -145,7 +162,6 @@
 
   class LokiSnodeChannel {
     constructor() {
-
       this._ephemeralKeyPair = generateEphemeralKeyPair();
       this._ephemeralPubKeyHex = StringView.arrayBufferToHex(
         this._ephemeralKeyPair.pubKey

--- a/libloki/storage.js
+++ b/libloki/storage.js
@@ -240,6 +240,14 @@
     return window.Signal.Data.getSecondaryDevicesFor(primaryDevicePubKey);
   }
 
+  function getGuardNodes() {
+    return window.Signal.Data.getGuardNodes();
+  }
+
+  function updateGuardNodes(nodes) {
+    return window.Signal.Data.updateGuardNodes(nodes);
+  }
+
   async function getAllDevicePubKeysForPrimaryPubKey(primaryDevicePubKey) {
     await saveAllPairingAuthorisationsFor(primaryDevicePubKey);
     const secondaryPubKeys =
@@ -265,6 +273,8 @@
     getAllDevicePubKeysForPrimaryPubKey,
     getSecondaryDevicesFor,
     getPrimaryDeviceMapping,
+    getGuardNodes,
+    updateGuardNodes
   };
 
   // Libloki protocol store

--- a/libloki/storage.js
+++ b/libloki/storage.js
@@ -274,7 +274,7 @@
     getSecondaryDevicesFor,
     getPrimaryDeviceMapping,
     getGuardNodes,
-    updateGuardNodes
+    updateGuardNodes,
   };
 
   // Libloki protocol store

--- a/libtextsecure/stringview.js
+++ b/libtextsecure/stringview.js
@@ -26,6 +26,7 @@
                 : 0;
     },
 
+    // This is not a "standard" base64, do not use!
     base64ToBytes(sBase64, nBlocksSize) {
       const sB64Enc = sBase64.replace(/[^A-Za-z0-9+/]/g, '');
       const nInLen = sB64Enc.length;

--- a/preload.js
+++ b/preload.js
@@ -420,7 +420,11 @@ Promise.prototype.ignore = function() {
   this.then(() => {});
 };
 
-if (config.environment.includes('test') && !config.environment == "swarm-testing1" && !config.environment == "swarm-testing2") {
+if (
+  config.environment.includes('test') &&
+  !config.environment === 'swarm-testing1' &&
+  !config.environment === 'swarm-testing2'
+) {
   const isWindows = process.platform === 'win32';
   /* eslint-disable global-require, import/no-extraneous-dependencies */
   window.test = {

--- a/preload.js
+++ b/preload.js
@@ -411,7 +411,7 @@ window.lokiFeatureFlags = {
   privateGroupChats: true,
   useSnodeProxy: true,
   useSealedSender: true,
-  useOnionRequests: true,
+  useOnionRequests: false,
 };
 
 // eslint-disable-next-line no-extend-native,func-names

--- a/preload.js
+++ b/preload.js
@@ -411,6 +411,7 @@ window.lokiFeatureFlags = {
   privateGroupChats: true,
   useSnodeProxy: true,
   useSealedSender: true,
+  useOnionRequests: true,
 };
 
 // eslint-disable-next-line no-extend-native,func-names
@@ -419,7 +420,7 @@ Promise.prototype.ignore = function() {
   this.then(() => {});
 };
 
-if (config.environment.includes('test')) {
+if (config.environment.includes('test') && !config.environment == "swarm-testing1" && !config.environment == "swarm-testing2") {
   const isWindows = process.platform === 'win32';
   /* eslint-disable global-require, import/no-extraneous-dependencies */
   window.test = {
@@ -439,5 +440,6 @@ if (config.environment.includes('test')) {
     updateSwarmNodes: () => {},
     updateLastHash: () => {},
     getSwarmNodesForPubKey: () => [],
+    buildNewOnionPaths: () => [],
   };
 }


### PR DESCRIPTION
- Disable long-polling
- Onion path building with guard nodes: guard nodes persist in DB; there is a path per every guard node; every path rebuild tries to reuse existing guard nodes
- Added GCM encryption used for every node on the path