### PR TITLE
disable link option on secondary device

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1006,6 +1006,9 @@
   "noPairedDevices": {
     "message": "No paired devices"
   },
+  "deviceIsSecondaryNoPairing": {
+    "message": "This device is a secondary device and so cannot be paired."
+  },
   "allowPairing": {
     "message": "Allow Pairing"
   },

--- a/ts/components/MainViewController.tsx
+++ b/ts/components/MainViewController.tsx
@@ -14,9 +14,13 @@ export const MainViewController = {
   },
 
   renderSettingsView: (category: SessionSettingCategory) => {
+    // tslint:disable-next-line: no-backbone-get-set-outside-model
+    const isSecondaryDevice = !!window.textsecure.storage.get(
+      'isSecondaryDevice'
+    );
     if (document.getElementById('main-view')) {
       ReactDOM.render(
-        <SettingsView category={category} />,
+        <SettingsView category={category} isSecondaryDevice={isSecondaryDevice}/>,
         document.getElementById('main-view')
       );
     }

--- a/ts/components/MainViewController.tsx
+++ b/ts/components/MainViewController.tsx
@@ -20,7 +20,10 @@ export const MainViewController = {
     );
     if (document.getElementById('main-view')) {
       ReactDOM.render(
-        <SettingsView category={category} isSecondaryDevice={isSecondaryDevice}/>,
+        <SettingsView
+          category={category}
+          isSecondaryDevice={isSecondaryDevice}
+        />,
         document.getElementById('main-view')
       );
     }

--- a/ts/components/session/settings/SessionSettings.tsx
+++ b/ts/components/session/settings/SessionSettings.tsx
@@ -577,7 +577,6 @@ export class SettingsView extends React.Component<SettingsViewProps, State> {
   private getLinkedDeviceSettings(): Array<LocalSettingType> {
     const { linkedPubKeys } = this.state;
     const { isSecondaryDevice } = this.props;
-    // tslint:disable-next-line: no-backbone-get-set-outside-model
     const noPairedDeviceText = isSecondaryDevice
       ? window.i18n('deviceIsSecondaryNoPairing')
       : window.i18n('noPairedDevices');

--- a/ts/components/session/settings/SessionSettings.tsx
+++ b/ts/components/session/settings/SessionSettings.tsx
@@ -27,6 +27,7 @@ export enum SessionSettingType {
 
 export interface SettingsViewProps {
   category: SessionSettingCategory;
+  isSecondaryDevice: boolean;
 }
 
 interface State {
@@ -221,7 +222,7 @@ export class SettingsView extends React.Component<SettingsViewProps, State> {
   }
 
   public render() {
-    const { category } = this.props;
+    const { category, isSecondaryDevice } = this.props;
     const shouldRenderPasswordLock =
       this.state.shouldLockSettings && this.state.hasPassword;
 
@@ -230,6 +231,7 @@ export class SettingsView extends React.Component<SettingsViewProps, State> {
         <SettingsHeader
           showLinkDeviceButton={!shouldRenderPasswordLock}
           category={category}
+          isSecondaryDevice={isSecondaryDevice}
         />
 
         <div className="session-settings-view">
@@ -574,6 +576,11 @@ export class SettingsView extends React.Component<SettingsViewProps, State> {
 
   private getLinkedDeviceSettings(): Array<LocalSettingType> {
     const { linkedPubKeys } = this.state;
+    const { isSecondaryDevice } = this.props;
+    // tslint:disable-next-line: no-backbone-get-set-outside-model
+    const noPairedDeviceText = isSecondaryDevice
+      ? window.i18n('deviceIsSecondaryNoPairing')
+      : window.i18n('noPairedDevices');
 
     if (linkedPubKeys && linkedPubKeys.length > 0) {
       return linkedPubKeys.map((pubkey: any) => {
@@ -621,7 +628,7 @@ export class SettingsView extends React.Component<SettingsViewProps, State> {
       return [
         {
           id: 'no-linked-device',
-          title: window.i18n('noPairedDevices'),
+          title: noPairedDeviceText,
           type: undefined,
           description: '',
           category: SessionSettingCategory.Devices,

--- a/ts/components/session/settings/SessionSettingsHeader.tsx
+++ b/ts/components/session/settings/SessionSettingsHeader.tsx
@@ -5,7 +5,9 @@ import { SessionSettingCategory, SettingsViewProps } from './SessionSettings';
 import { SessionButton } from '../SessionButton';
 
 interface Props extends SettingsViewProps {
+  // showLinkDeviceButton is used to completely hide the button while the settings password lock is displayed
   showLinkDeviceButton: boolean | null;
+  // isSecondaryDevice is used to just disable the linkDeviceButton when we are already a secondary device
   isSecondaryDevice: boolean;
 }
 
@@ -16,6 +18,8 @@ export class SettingsHeader extends React.Component<Props, any> {
 
   public constructor(props: any) {
     super(props);
+    // mark the linkDeviceButton as disabled by default.
+    // it will be enabled if needed during componentDidMount().
     this.state = {
       disableLinkDeviceButton: true,
     };

--- a/ts/components/session/settings/SessionSettingsHeader.tsx
+++ b/ts/components/session/settings/SessionSettingsHeader.tsx
@@ -6,19 +6,18 @@ import { SessionButton } from '../SessionButton';
 
 interface Props extends SettingsViewProps {
   showLinkDeviceButton: boolean | null;
-  disableLinkDeviceButton: boolean | null;
+  isSecondaryDevice: boolean;
 }
 
 export class SettingsHeader extends React.Component<Props, any> {
   public static defaultProps = {
     showLinkDeviceButton: false,
-    disableLinkDeviceButton: true,
   };
 
   public constructor(props: any) {
     super(props);
     this.state = {
-      disableLinkDeviceButton: this.props.disableLinkDeviceButton,
+      disableLinkDeviceButton: true,
     };
     this.showAddLinkedDeviceModal = this.showAddLinkedDeviceModal.bind(this);
   }
@@ -32,10 +31,12 @@ export class SettingsHeader extends React.Component<Props, any> {
   }
 
   public componentDidMount() {
-    window.Whisper.events.on('refreshLinkedDeviceList', async () => {
+    if (!this.props.isSecondaryDevice) {
+      window.Whisper.events.on('refreshLinkedDeviceList', async () => {
+        this.refreshLinkedDevice();
+      });
       this.refreshLinkedDevice();
-    });
-    this.refreshLinkedDevice();
+    }
   }
 
   public refreshLinkedDevice() {
@@ -51,7 +52,9 @@ export class SettingsHeader extends React.Component<Props, any> {
   }
 
   public componentWillUnmount() {
-    window.Whisper.events.off('refreshLinkedDeviceList');
+    if (!this.props.isSecondaryDevice) {
+      window.Whisper.events.off('refreshLinkedDeviceList');
+    }
   }
 
   public render() {


### PR DESCRIPTION
Disable the settings button allowing to linking a new device when the current device is already a current device