### PR TITLE
default to en_US if locale dictionnary is not found

### DIFF
--- a/js/spell_check.js
+++ b/js/spell_check.js
@@ -64,7 +64,7 @@ function setupLinux(locale) {
 
   window.log.info('Detected Linux. Using default en_US spell check dictionary');
 
-  return new Typo(locale);
+  return new Typo('en_US');
 }
 
 // We load locale this way and not via app.getLocale() because this call returns


### PR DESCRIPTION
#1013 