### PR TITLE
make closed group create button clickable (via minimum height), onBlur calls onChange

### DIFF
--- a/main.js
+++ b/main.js
@@ -199,9 +199,11 @@ function captureClicks(window) {
 }
 
 const DEFAULT_WIDTH = 880;
-const DEFAULT_HEIGHT = 720;
+// add contact button needs to be visible (on HiDpi screens?)
+// otherwise integration test fail
+const DEFAULT_HEIGHT = 820;
 const MIN_WIDTH = 880;
-const MIN_HEIGHT = 720;
+const MIN_HEIGHT = 820;
 const BOUNDS_BUFFER = 100;
 
 function isVisible(window, bounds) {

--- a/ts/components/session/SessionIdEditable.tsx
+++ b/ts/components/session/SessionIdEditable.tsx
@@ -45,6 +45,7 @@ export class SessionIdEditable extends React.PureComponent<Props> {
           spellCheck={false}
           onKeyDown={this.handleKeyDown}
           onChange={this.handleChange}
+          onBlur={this.handleChange}
           value={value || text}
           maxLength={maxLength}
         />

--- a/ts/components/session/SessionInput.tsx
+++ b/ts/components/session/SessionInput.tsx
@@ -61,6 +61,10 @@ export class SessionInput extends React.PureComponent<Props, State> {
           className={classNames(
             enableShowHide ? 'session-input-floating-label-show-hide' : ''
           )}
+          // just incase onChange isn't triggered
+          onBlur={e => {
+            this.updateInputValue(e);
+          }}
           onKeyPress={event => {
             event.persist();
             if (event.key === 'Enter' && this.props.onEnterPressed) {


### PR DESCRIPTION
- integration tests needs the mouse to be able to click on the closed group create button. This means it needs to be visible.
- since my next PR we use JS to inject values in integration testing (to work around a spectron bug), the onChange event doesn't fire, added an onBlue handler to make sure the state value is accurate. This may fix #1021 because this is the exact behavior I caught in the integration test.