### PR TITLE
fix lastHash retreival

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -2473,7 +2473,7 @@ async function getLastHashBySnode(snode) {
     return null;
   }
 
-  return row.lastHash;
+  return row.hash;
 }
 
 async function getSeenMessagesByHashList(hashes) {


### PR DESCRIPTION
This fixes a bug with the getting the lastHash from SQL, we were reading the wrong field.

This fix seems to break receiving messages from snodes (As it's seemingly the correct behavior but maybe other bugs that it now triggers).

No big deal without merging this but it should reduce bandwidth usage and some processing on the storage servers.
