### PR TITLE
Fix CPU usage when using onion requests

### DIFF
--- a/js/modules/loki_app_dot_net_api.js
+++ b/js/modules/loki_app_dot_net_api.js
@@ -98,7 +98,7 @@ const sendToProxy = async (
   payloadObj.body = false; // free memory
 
   // make temporary key for this request/response
-  const ephemeralKey = libsignal.Curve.generateKeyPair();
+  const ephemeralKey = await libsignal.Curve.async.generateKeyPair();
 
   // mix server pub key with our priv key
   const symKey = libsignal.Curve.calculateAgreement(

--- a/js/modules/loki_app_dot_net_api.js
+++ b/js/modules/loki_app_dot_net_api.js
@@ -101,7 +101,7 @@ const sendToProxy = async (
   const ephemeralKey = await libsignal.Curve.async.generateKeyPair();
 
   // mix server pub key with our priv key
-  const symKey = libsignal.Curve.calculateAgreement(
+  const symKey = await libsignal.Curve.async.calculateAgreement(
     srvPubKey, // server's pubkey
     ephemeralKey.privKey // our privkey
   );

--- a/js/modules/loki_rpc.js
+++ b/js/modules/loki_rpc.js
@@ -22,7 +22,7 @@ const encryptForNode = async (node, payload) => {
 
   const snPubkey = StringView.hexToArrayBuffer(node.pubkey_x25519);
 
-  const ephemeralSecret = libsignal.Curve.calculateAgreement(
+  const ephemeralSecret = await libsignal.Curve.async.calculateAgreement(
     snPubkey,
     ephemeral.privKey
   );
@@ -237,7 +237,7 @@ const sendToProxy = async (options = {}, targetNode, retryNumber = 0) => {
 
   const myKeys = await window.libloki.crypto.generateEphemeralKeyPair();
 
-  const symmetricKey = libsignal.Curve.calculateAgreement(
+  const symmetricKey = await libsignal.Curve.async.calculateAgreement(
     snPubkeyHex,
     myKeys.privKey
   );

--- a/js/modules/loki_rpc.js
+++ b/js/modules/loki_rpc.js
@@ -18,7 +18,7 @@ const encryptForNode = async (node, payload) => {
   const textEncoder = new TextEncoder();
   const plaintext = textEncoder.encode(payload);
 
-  const ephemeral = libloki.crypto.generateEphemeralKeyPair();
+  const ephemeral = await libloki.crypto.generateEphemeralKeyPair();
 
   const snPubkey = StringView.hexToArrayBuffer(node.pubkey_x25519);
 
@@ -235,7 +235,7 @@ const sendToProxy = async (options = {}, targetNode, retryNumber = 0) => {
 
   const snPubkeyHex = StringView.hexToArrayBuffer(targetNode.pubkey_x25519);
 
-  const myKeys = window.libloki.crypto.generateEphemeralKeyPair();
+  const myKeys = await window.libloki.crypto.generateEphemeralKeyPair();
 
   const symmetricKey = libsignal.Curve.calculateAgreement(
     snPubkeyHex,

--- a/libloki/crypto.js
+++ b/libloki/crypto.js
@@ -99,7 +99,7 @@
         throw new Error('Failed to get keypair for encryption');
       }
       const myPrivateKey = myKeyPair.privKey;
-      const symmetricKey = libsignal.Curve.calculateAgreement(
+      const symmetricKey = await libsignal.Curve.async.calculateAgreement(
         this.pubKey,
         myPrivateKey
       );
@@ -117,7 +117,7 @@
         throw new Error('Failed to get keypair for decryption');
       }
       const myPrivateKey = myKeyPair.privKey;
-      const symmetricKey = libsignal.Curve.calculateAgreement(
+      const symmetricKey = await libsignal.Curve.async.calculateAgreement(
         this.pubKey,
         myPrivateKey
       );
@@ -290,7 +290,7 @@
       throw new Error('Failed to get keypair for token decryption');
     }
     const { privKey } = keyPair;
-    const symmetricKey = libsignal.Curve.calculateAgreement(
+    const symmetricKey = await libsignal.Curve.async.calculateAgreement(
       serverPubKey,
       privKey
     );

--- a/libloki/crypto.js
+++ b/libloki/crypto.js
@@ -144,8 +144,8 @@
     return Multibase.decode(`${base32zCode}${snodeAddressClean}`);
   }
 
-  function generateEphemeralKeyPair() {
-    const keys = libsignal.Curve.generateKeyPair();
+  async function generateEphemeralKeyPair() {
+    const keys = await libsignal.Curve.async.generateKeyPair();
     // Signal protocol prepends with "0x05"
     keys.pubKey = keys.pubKey.slice(1);
     return keys;


### PR DESCRIPTION
The solution was simple ...

Signal has 2 curve implementations, a `sync` and an `async`. We were using the `sync` version so the expensive crypto functions were being run on the main thread. The `async` versions pass this off to a worker.