### PR TITLE
Fix corner cases for registration reset

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -2762,6 +2762,10 @@ async function removeAll() {
       db.run('DELETE FROM contactSignedPreKeys;'),
       db.run('DELETE FROM attachment_downloads;'),
       db.run('DELETE FROM messages_fts;'),
+      db.run('DELETE FROM servers;'),
+      db.run('DELETE FROM lastHashes;'),
+      db.run('DELETE FROM seenMessages;'),
+      db.run('DELETE FROM sessions;'),
       db.run('COMMIT TRANSACTION;'),
     ]);
   });
@@ -2784,6 +2788,7 @@ async function removeAllConfiguration() {
       db.run('DELETE FROM unprocessed;'),
       db.run('DELETE FROM contactPreKeys;'),
       db.run('DELETE FROM contactSignedPreKeys;'),
+      db.run('DELETE FROM servers;'),
       db.run('COMMIT TRANSACTION;'),
     ]);
   });

--- a/ts/components/session/RegistrationTabs.tsx
+++ b/ts/components/session/RegistrationTabs.tsx
@@ -713,13 +713,8 @@ export class RegistrationTabs extends React.Component<{}, State> {
   }
 
   private async resetRegistration() {
-    await window.Signal.Data.removeAllIdentityKeys();
-    await window.Signal.Data.removeAllPrivateConversations();
-    window.Whisper.Registration.remove();
-    // Do not remove all items since they are only set
-    // at startup.
-    window.textsecure.storage.remove('identityKey');
-    window.textsecure.storage.remove('secondaryDeviceStatus');
+    await window.Signal.Data.removeAll();
+    await window.storage.fetch();
     window.ConversationController.reset();
     await window.ConversationController.load();
     window.Whisper.RotateSignedPreKeyListener.stop(window.Whisper.events);


### PR DESCRIPTION
One of the cases was that the file server tokens weren't removed causing the a fresh registration to upload device links to a different user.

I've changed the reset so it removed all data, and from debugging it doesn't seem to cause issues but i will keep testing.