### PR TITLE
Ignore multi device logic when sending a background message

### DIFF
--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -338,7 +338,8 @@ OutgoingMessage.prototype = {
         let thisDeviceMessageType = this.messageType;
         if (
           thisDeviceMessageType !== 'pairing-request' &&
-          thisDeviceMessageType !== 'friend-request'
+          thisDeviceMessageType !== 'friend-request' &&
+          thisDeviceMessageType !== 'onlineBroadcast'
         ) {
           let conversation;
           try {


### PR DESCRIPTION
This fixes the issue where desktop sends out a background friend request after accepting a session request