### PR TITLE
Ignore multi device logic when sending background message

### DIFF
--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -301,7 +301,8 @@ OutgoingMessage.prototype = {
     let thisDeviceMessageType = this.messageType;
     if (
       thisDeviceMessageType !== 'pairing-request' &&
-      thisDeviceMessageType !== 'friend-request'
+      thisDeviceMessageType !== 'friend-request' &&
+      thisDeviceMessageType !== 'onlineBroadcast'
     ) {
       try {
         const conversation = ConversationController.get(devicePubKey);


### PR DESCRIPTION
This fixes the issue where desktop sends out a background friend request after accepting a session request.

We will need to get this tested to make sure it doesn't break other logic.