### PR TITLE
Medium groups with sender keys (essentials)

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -3,10 +3,6 @@
     {
       "ip": "public.loki.foundation",
       "port": "38157"
-    },
-    {
-      "ip": "storage.testnetseed1.loki.network",
-      "port": "38157"
     }
   ],
   "openDevTools": true,

--- a/config/swarm-testing.json
+++ b/config/swarm-testing.json
@@ -1,9 +1,13 @@
 {
   "seedNodeList": [
     {
-      "ip": "localhost",
+      "ip": "127.0.0.1",
       "port": "22129"
     }
+    // {
+    //   "ip": "167.114.135.147",
+    //   "port": "22129"
+    // }
   ],
   "openDevTools": true,
   "defaultPublicChatServer": "https://team-chat.lokinet.org/"

--- a/config/swarm-testing.json
+++ b/config/swarm-testing.json
@@ -4,10 +4,6 @@
       "ip": "127.0.0.1",
       "port": "22129"
     }
-    // {
-    //   "ip": "167.114.135.147",
-    //   "port": "22129"
-    // }
   ],
   "openDevTools": true,
   "defaultPublicChatServer": "https://team-chat.lokinet.org/"

--- a/js/background.js
+++ b/js/background.js
@@ -742,15 +742,17 @@
         ourIdentity
       );
 
+      const groupSecretKeyHex = StringView.arrayBufferToHex(
+        identityKeys.privKey
+      );
+
       // Constructing a "create group" message
       const proto = new textsecure.protobuf.DataMessage();
 
       const groupUpdate = new textsecure.protobuf.MediumGroupUpdate();
 
       groupUpdate.groupId = groupId;
-      groupUpdate.groupSecretKey = StringView.arrayBufferToHex(
-        identityKeys.privKey
-      );
+      groupUpdate.groupSecretKey = groupSecretKeyHex;
       groupUpdate.senderKey = senderKey;
       groupUpdate.members = [ourIdentity, ...members];
       groupUpdate.groupName = groupName;
@@ -758,7 +760,7 @@
 
       await window.Signal.Data.createOrUpdateIdentityKey({
         id: groupId,
-        secretKey: identityKeys.privKey,
+        secretKey: groupSecretKeyHex,
       });
 
       const convo = await window.ConversationController.getOrCreateAndWait(

--- a/js/background.js
+++ b/js/background.js
@@ -730,6 +730,57 @@
       });
     };
 
+    window.createMediumSizeGroup = async (groupName, members) => {
+      // Create Group Identity
+      const identityKeys = await libsignal.KeyHelper.generateIdentityKeyPair();
+      const groupId = StringView.arrayBufferToHex(identityKeys.pubKey);
+
+      const ourIdentity = await textsecure.storage.user.getNumber();
+
+      const senderKey = await window.SenderKeyAPI.createSenderKeyForGroup(
+        groupId,
+        ourIdentity
+      );
+
+      // Constructing a "create group" message
+      const proto = new textsecure.protobuf.DataMessage();
+
+      const groupUpdate = new textsecure.protobuf.MediumGroupUpdate();
+
+      groupUpdate.groupId = groupId;
+      groupUpdate.groupSecretKey = StringView.arrayBufferToHex(
+        identityKeys.privKey
+      );
+      groupUpdate.senderKey = senderKey;
+      groupUpdate.members = [ourIdentity, ...members];
+      groupUpdate.groupName = groupName;
+      proto.mediumGroupUpdate = groupUpdate;
+
+      await window.Signal.Data.createOrUpdateIdentityKey({
+        id: groupId,
+        secretKey: identityKeys.privKey,
+      });
+
+      const convo = await window.ConversationController.getOrCreateAndWait(
+        groupId,
+        Message.GROUP
+      );
+
+      convo.set('is_medium_group', true);
+      convo.set('active_at', Date.now());
+      convo.set('name', groupName);
+
+      convo.setFriendRequestStatus(
+        window.friends.friendRequestStatusEnum.friends
+      );
+
+      // Subscribe to this group id
+      messageReceiver.pollForAdditionalId(groupId);
+
+      // TODO: include ourselves so that our lined devices work as well!
+      await textsecure.messaging.updateMediumGroup(members, proto);
+    };
+
     window.doCreateGroup = async (groupName, members) => {
       const keypair = await libsignal.KeyHelper.generateIdentityKeyPair();
       const groupId = StringView.arrayBufferToHex(keypair.pubKey);

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1734,10 +1734,19 @@
                 profileKey,
                 options
               );
-            case Message.GROUP:
+            case Message.GROUP: {
+              let dest = destination;
+              let numbers = groupNumbers;
+
+              if (this.get('is_medium_group')) {
+                dest = this.id;
+                numbers = [destination];
+                options.isMediumGroup = true;
+              }
+
               return textsecure.messaging.sendMessageToGroup(
-                destination,
-                groupNumbers,
+                dest,
+                numbers,
                 messageBody,
                 finalAttachments,
                 quote,
@@ -1747,6 +1756,7 @@
                 profileKey,
                 options
               );
+            }
             default:
               throw new TypeError(
                 `Invalid conversation type: '${conversationType}'`

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -207,6 +207,9 @@ module.exports = {
   getLegacyMessagesNeedingUpgrade,
   getMessagesWithVisualMediaAttachments,
   getMessagesWithFileAttachments,
+
+  getSenderKeys,
+  createOrUpdateSenderKeys,
 };
 
 // When IPC arguments are prepared for the cross-process send, they are JSON.stringified.
@@ -721,6 +724,16 @@ async function removeAllItems() {
   await channels.removeAllItems();
 }
 
+// Sender Keys
+
+async function getSenderKeys(groupId, senderIdentity) {
+  return channels.getSenderKeys(groupId, senderIdentity);
+}
+
+async function createOrUpdateSenderKeys(data) {
+  await channels.createOrUpdateSenderKeys(data);
+}
+
 // Sessions
 
 async function createOrUpdateSession(data) {
@@ -1071,8 +1084,8 @@ async function getMessagesByConversation(
   return new MessageCollection(messages);
 }
 
-async function getLastHashBySnode(snode) {
-  return channels.getLastHashBySnode(snode);
+async function getLastHashBySnode(convoId, snode) {
+  return channels.getLastHashBySnode(convoId, snode);
 }
 
 async function getSeenMessagesByHashList(hashes) {

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -62,6 +62,8 @@ async function _retrieveNextMessages(nodeData, pubkey) {
         nodeData.ip
       }:${nodeData.port}`
     );
+
+    return [];
   }
 
   return result.messages || [];

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -32,6 +32,41 @@ const calcNonce = (messageEventData, pubKey, data64, timestamp, ttl) => {
   return callWorker('calcPoW', timestamp, ttl, pubKey, data64, difficulty);
 };
 
+// we don't throw or catch here
+// mark private (_ prefix) since no error handling is done here...
+async function _retrieveNextMessages(nodeData, pubkey) {
+  const params = {
+    pubKey: pubkey,
+    lastHash: nodeData.lastHash || '',
+  };
+  const options = {
+    timeout: 40000,
+    ourPubKey: pubkey,
+  };
+
+  // let exceptions bubble up
+  const result = await lokiRpc(
+    `https://${nodeData.ip}`,
+    nodeData.port,
+    'retrieve',
+    params,
+    options,
+    '/storage_rpc/v1',
+    nodeData
+  );
+
+  if (result === false) {
+    // make a note of it because of caller doesn't care...
+    log.warn(
+      `loki_message:::_retrieveNextMessages - lokiRpc could not talk to ${
+        nodeData.ip
+      }:${nodeData.port}`
+    );
+  }
+
+  return result.messages || [];
+}
+
 class LokiMessageAPI {
   constructor(ourKey) {
     this.jobQueue = new window.JobQueue();
@@ -271,7 +306,93 @@ class LokiMessageAPI {
     return false;
   }
 
-  async _openRetrieveConnection(pSwarmPool, stopPollingPromise, callback) {
+  async pollNodeForGroupId(groupId, nodeParam, onMessages) {
+    const node = nodeParam;
+    const lastHash = await window.Signal.Data.getLastHashBySnode(
+      groupId,
+      node.address
+    );
+
+    node.lastHash = lastHash;
+
+    log.debug(
+      `[last hash] lashHash for group id ${groupId.substr(0, 5)}: node ${
+        node.port
+      }`,
+      lastHash
+    );
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      try {
+        let messages = await _retrieveNextMessages(node, groupId);
+
+        if (messages.length > 0) {
+          const lastMessage = _.last(messages);
+
+          // TODO: this is for groups, so need to specify ID
+
+          // Is this too early to update last hash??
+          await lokiSnodeAPI.updateLastHash(
+            groupId,
+            node.address,
+            lastMessage.hash,
+            lastMessage.expiration
+          );
+          log.debug(
+            `Updated lashHash for group id ${groupId.substr(0, 5)}: node ${
+              node.port
+            }`,
+            lastMessage.hash
+          );
+
+          node.lastHash = lastMessage.hash;
+
+          messages = await this.jobQueue.add(() =>
+            filterIncomingMessages(messages)
+          );
+
+          // At this point we still know what servier identity the messages
+          // are associated with, so we save it in messages' conversationId field:
+          const modifiedMessages = messages.map(m => {
+            // eslint-disable-next-line no-param-reassign
+            m.conversationId = groupId;
+            return m;
+          });
+
+          onMessages(modifiedMessages);
+        }
+      } catch (e) {
+        log.warn('');
+
+        log.warn(
+          'pollNodeForGroupId - retrieve error:',
+          e.code,
+          e.message,
+          `on ${node.ip}:${node.port}`
+        );
+
+        // TODO: Handle unreachable nodes and wrong swarms
+      }
+
+      await primitives.sleepFor(5000);
+    }
+  }
+
+  async pollForGroupId(groupId, onMessages) {
+    log.info(`Starting to poll for group id: ${groupId}`);
+
+    // Get nodes for groupId
+    const nodes = await lokiSnodeAPI.refreshSwarmNodesForPubKey(groupId);
+
+    log.info('Nodes for group id:', nodes);
+
+    _.sampleSize(nodes, 3).forEach(node =>
+      this.pollNodeForGroupId(groupId, node, onMessages)
+    );
+  }
+
+  async _openRetrieveConnection(pSwarmPool, stopPollingPromise, onMessages) {
     const swarmPool = pSwarmPool; // lint
     let stopPollingResult = false;
 
@@ -299,8 +420,8 @@ class LokiMessageAPI {
           // so the user facing UI can report unhandled errors
           // except in this case of living inside http-resource pollServer
           // because it just restarts more connections...
+          let messages = await _retrieveNextMessages(nodeData, this.ourKey);
 
-          let messages = await this._retrieveNextMessages(nodeData);
           // this only tracks retrieval failures
           // won't include parsing failures...
           successiveFailures = 0;
@@ -308,6 +429,7 @@ class LokiMessageAPI {
             const lastMessage = _.last(messages);
             nodeData.lastHash = lastMessage.hash;
             await lokiSnodeAPI.updateLastHash(
+              this.ourKey,
               address,
               lastMessage.hash,
               lastMessage.expiration
@@ -317,7 +439,7 @@ class LokiMessageAPI {
             );
           }
           // Execute callback even with empty array to signal online status
-          callback(messages);
+          onMessages(messages);
         } catch (e) {
           log.warn(
             'loki_message:::_openRetrieveConnection - retrieve error:',
@@ -327,11 +449,15 @@ class LokiMessageAPI {
           );
           if (e instanceof textsecure.WrongSwarmError) {
             const { newSwarm } = e;
+
+            // Is this a security concern that we replace the list of snodes
+            // based on a response from a single snode?
             await lokiSnodeAPI.updateSwarmNodes(this.ourKey, newSwarm);
             // FIXME: restart all openRetrieves when this happens...
             // FIXME: lokiSnode should handle this
             for (let i = 0; i < newSwarm.length; i += 1) {
               const lastHash = await window.Signal.Data.getLastHashBySnode(
+                this.ourKey,
                 newSwarm[i]
               );
               swarmPool[newSwarm[i]] = {
@@ -379,46 +505,26 @@ class LokiMessageAPI {
   }
 
   // we don't throw or catch here
-  // mark private (_ prefix) since no error handling is done here...
-  async _retrieveNextMessages(nodeData) {
-    const params = {
-      pubKey: this.ourKey,
-      lastHash: nodeData.lastHash || '',
-    };
-    const options = {
-      timeout: 40000,
-      ourPubKey: this.ourKey,
-    };
-
-    // let exceptions bubble up
-    const result = await lokiRpc(
-      `https://${nodeData.ip}`,
-      nodeData.port,
-      'retrieve',
-      params,
-      options,
-      '/storage_rpc/v1',
-      nodeData
-    );
-
-    if (result === false) {
-      // make a note of it because of caller doesn't care...
-      log.warn(
-        `loki_message:::_retrieveNextMessages - lokiRpc could not talk to ${
-          nodeData.ip
-        }:${nodeData.port}`
-      );
-    }
-
-    return result.messages || [];
-  }
-
-  // we don't throw or catch here
-  async startLongPolling(numConnections, stopPolling, callback) {
+  async startLongPolling(numConnections, stopPolling, onMessages) {
     // load from local DB
     let nodes = await lokiSnodeAPI.getSwarmNodesForPubKey(this.ourKey, {
       fetchHashes: true,
     });
+
+    // Start polling for medium size groups as well (they might be in different swarms)
+    {
+      const convos = window
+        .getConversations()
+        .filter(c => c.get('is_medium_group'));
+
+      const self = this;
+
+      convos.forEach(c => {
+        self.pollForGroupId(c.id, onMessages);
+        // TODO: unsubscribe if the group is deleted
+      });
+    }
+
     if (nodes.length < numConnections) {
       log.warn(
         'loki_message:::startLongPolling - Not enough SwarmNodes for our pubkey in local database, getting current list from blockchain'
@@ -462,7 +568,7 @@ class LokiMessageAPI {
     for (let i = 0; i < numConnections; i += 1) {
       promises.push(
         // eslint-disable-next-line more/no-then
-        this._openRetrieveConnection(pools[i], stopPolling, callback).then(
+        this._openRetrieveConnection(pools[i], stopPolling, onMessages).then(
           stoppedPolling => {
             unresolved -= 1;
             log.info(

--- a/js/modules/loki_sender_key_api.js
+++ b/js/modules/loki_sender_key_api.js
@@ -1,0 +1,300 @@
+/* global
+  Signal,
+  libsignal,
+  StringView,
+  dcodeIO,
+  libloki,
+  log,
+  crypto
+*/
+
+/* eslint-disable more/no-then */
+
+const toHex = buffer => StringView.arrayBufferToHex(buffer);
+
+const fromHex = hex => dcodeIO.ByteBuffer.wrap(hex, 'hex').toArrayBuffer();
+
+async function saveSenderKeysInner(
+  groupId,
+  senderIdentity,
+  chainKey,
+  keyIdx,
+  messageKeys
+) {
+  const ratchet = {
+    chainKey,
+    messageKeys,
+    idx: keyIdx,
+  };
+
+  await Signal.Data.createOrUpdateSenderKeys({
+    groupId,
+    senderIdentity,
+    ratchet,
+  });
+
+  log.debug(
+    `Saving sender keys for groupId ${groupId}, sender ${senderIdentity}`
+  );
+}
+
+// Save somebody else's key
+async function saveSenderKeys(groupId, senderIdentity, chainKey) {
+  // New key, so index 0
+  const keyIdx = 0;
+  const messageKeys = {};
+  await saveSenderKeysInner(
+    groupId,
+    senderIdentity,
+    chainKey,
+    keyIdx,
+    messageKeys
+  );
+}
+
+async function createSenderKeyForGroup(groupId, senderIdentity) {
+  // Generate Chain Key (32 random bytes)
+  const rootChainKey = await libsignal.crypto.getRandomBytes(32);
+  const rootChainKeyHex = toHex(rootChainKey);
+
+  const keyIdx = 0;
+  const messageKeys = {};
+
+  await saveSenderKeysInner(
+    groupId,
+    senderIdentity,
+    rootChainKeyHex,
+    keyIdx,
+    messageKeys
+  );
+
+  return rootChainKeyHex;
+}
+
+async function hmacSHA256(keybuf, data) {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    keybuf,
+    { name: 'HMAC', hash: { name: 'SHA-256' } },
+    false,
+    ['sign']
+  );
+
+  return crypto.subtle.sign({ name: 'HMAC', hash: 'SHA-256' }, key, data);
+}
+
+async function stepRatchet(ratchet) {
+  const { chainKey, keyIdx, messageKeys } = ratchet;
+
+  const byteArray = new Uint8Array(1);
+  byteArray[0] = 1;
+  const messageKey = await hmacSHA256(chainKey, byteArray.buffer);
+
+  byteArray[0] = 2;
+  const nextChainKey = await hmacSHA256(chainKey, byteArray.buffer);
+
+  const nextKeyIdx = keyIdx + 1;
+
+  return { nextChainKey, messageKey, nextKeyIdx, messageKeys };
+}
+
+async function stepRatchetOnce(groupId, senderIdentity) {
+  const ratchet = await loadChainKey(groupId, senderIdentity);
+
+  if (!ratchet) {
+    log.error(
+      `Could not find ratchet for groupId ${groupId} sender: ${senderIdentity}`
+    );
+    return null;
+  }
+
+  const { nextChainKey, messageKey, nextKeyIdx } = await stepRatchet(ratchet);
+
+  // Don't need to remember message keys for a sending ratchet
+  const messageKeys = {};
+  const nextChainKeyHex = toHex(nextChainKey);
+
+  await saveSenderKeysInner(
+    groupId,
+    senderIdentity,
+    nextChainKeyHex,
+    nextKeyIdx,
+    messageKeys
+  );
+
+  return { messageKey, keyIdx: nextKeyIdx };
+}
+
+// Advance the ratchet until idx
+async function advanceRatchet(groupId, senderIdentity, idx) {
+  const ratchet = await loadChainKey(groupId, senderIdentity);
+
+  if (!ratchet) {
+    log.error(
+      `Could not find ratchet for groupId ${groupId} sender: ${senderIdentity}`
+    );
+    return null;
+  }
+
+  // Normally keyIdx will be 1 behind, in which case we stepRatchet one time only
+
+  if (idx < ratchet.keyIdx) {
+    // If the request is for some old index, retrieve the key generated earlier and
+    // remove it from the database (there is no need to advance the ratchet)
+    const messageKey = ratchet.messageKeys[idx];
+    if (messageKey) {
+      delete ratchet.messageKeys[idx];
+      // TODO: just pass in the ratchet?
+      const chainKeyHex = toHex(ratchet.chainKey);
+      await saveSenderKeysInner(
+        groupId,
+        senderIdentity,
+        chainKeyHex,
+        ratchet.keyIdx,
+        ratchet.messageKeys
+      );
+
+      return fromHex(messageKey);
+    }
+
+    log.error('[idx] not found key for idx: ', idx);
+    // I probably want a better error handling than this
+    return null;
+  }
+
+  const { messageKeys } = ratchet;
+
+  let curMessageKey;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // eslint-disable-next-line no-await-in-loop
+    const { nextKeyIdx, nextChainKey, messageKey } = await stepRatchet(ratchet);
+
+    ratchet.chainKey = nextChainKey;
+    ratchet.keyIdx = nextKeyIdx;
+
+    if (nextKeyIdx === idx) {
+      curMessageKey = messageKey;
+      break;
+    } else if (nextKeyIdx > idx) {
+      log.error('Developer error: nextKeyIdx > idx');
+    } else {
+      // Store keys for skipped nextKeyIdx, we might need them to decrypt
+      // messages that arrive out-of-order
+      messageKeys[nextKeyIdx] = toHex(messageKey);
+    }
+  }
+
+  const chainKeyHex = toHex(ratchet.chainKey);
+
+  await saveSenderKeysInner(
+    groupId,
+    senderIdentity,
+    chainKeyHex,
+    idx,
+    messageKeys
+  );
+
+  return curMessageKey;
+}
+
+async function loadChainKey(groupId, senderIdentity) {
+  const senderKeyEntry = await Signal.Data.getSenderKeys(
+    groupId,
+    senderIdentity
+  );
+
+  if (!senderKeyEntry) {
+    // TODO: we should try to request the key from the sender in this case
+    log.error(
+      `Sender key not found for group ${groupId} sender ${senderIdentity}`
+    );
+    // TODO: throw instead?
+    return null;
+  }
+
+  const {
+    chainKey: chainKeyHex,
+    idx: keyIdx,
+    messageKeys,
+  } = senderKeyEntry.ratchet;
+
+  if (!chainKeyHex) {
+    log.error('Chain key not found');
+    return null;
+  }
+
+  // TODO: This could fail if the data is not hex, handle
+  // this case
+  const chainKey = fromHex(chainKeyHex);
+
+  return { chainKey, keyIdx, messageKeys };
+}
+
+const jobQueue = {};
+
+function queueJobForNumber(number, runJob) {
+  const runPrevious = jobQueue[number] || Promise.resolve();
+  const runCurrent = runPrevious.then(runJob, runJob);
+  jobQueue[number] = runCurrent;
+  runCurrent.then(() => {
+    if (jobQueue[number] === runCurrent) {
+      delete jobQueue[number];
+    }
+  });
+  return runCurrent;
+}
+
+async function decryptWithSenderKey(
+  ciphertext,
+  curKeyIdx,
+  groupId,
+  senderIdentity
+) {
+  // We only want to serialize jobs with the same pair (groupId, senderIdentity)
+  const id = groupId + senderIdentity;
+  return queueJobForNumber(id, () =>
+    decryptWithSenderKeyInner(ciphertext, curKeyIdx, groupId, senderIdentity)
+  );
+}
+
+async function decryptWithSenderKeyInner(
+  ciphertext,
+  curKeyIdx,
+  groupId,
+  senderIdentity
+) {
+  const messageKey = await advanceRatchet(groupId, senderIdentity, curKeyIdx);
+
+  // TODO: this might fail, handle this
+  const plaintext = await libloki.crypto.DecryptGCM(
+    messageKey,
+    ciphertext.toArrayBuffer()
+  );
+
+  return plaintext;
+}
+
+async function encryptWithSenderKey(plaintext, groupId, ourIdentity) {
+  // We only want to serialize jobs with the same pair (groupId, ourIdentity)
+  const id = groupId + ourIdentity;
+  return queueJobForNumber(id, () =>
+    encryptWithSenderKeyInner(plaintext, groupId, ourIdentity)
+  );
+}
+
+async function encryptWithSenderKeyInner(plaintext, groupId, ourIdentity) {
+  const { messageKey, keyIdx } = await stepRatchetOnce(groupId, ourIdentity);
+
+  const ciphertext = await libloki.crypto.EncryptGCM(messageKey, plaintext);
+
+  return { ciphertext, keyIdx };
+}
+
+module.exports = {
+  createSenderKeyForGroup,
+  encryptWithSenderKey,
+  decryptWithSenderKey,
+  saveSenderKeys,
+};

--- a/js/modules/loki_sender_key_api.js
+++ b/js/modules/loki_sender_key_api.js
@@ -268,10 +268,7 @@ async function decryptWithSenderKeyInner(
   const messageKey = await advanceRatchet(groupId, senderIdentity, curKeyIdx);
 
   // TODO: this might fail, handle this
-  const plaintext = await libloki.crypto.DecryptGCM(
-    messageKey,
-    ciphertext.toArrayBuffer()
-  );
+  const plaintext = await libloki.crypto.DecryptGCM(messageKey, ciphertext);
 
   return plaintext;
 }

--- a/js/modules/loki_snode_api.js
+++ b/js/modules/loki_snode_api.js
@@ -643,9 +643,10 @@ class LokiSnodeAPI {
     this.randomSnodePool = _.without(this.randomSnodePool, snode);
   }
 
-  async updateLastHash(snodeAddress, hash, expiresAt) {
+  async updateLastHash(convoId, snodeAddress, hash, expiresAt) {
     // FIXME: handle rejections
     await window.Signal.Data.updateLastHash({
+      convoId,
       snode: snodeAddress,
       hash,
       expiresAt,
@@ -666,6 +667,7 @@ class LokiSnodeAPI {
             const node = swarmNodes[j];
             // FIXME make a batch function call
             const lastHash = await window.Signal.Data.getLastHashBySnode(
+              pubKey,
               node.address
             );
             log.debug(
@@ -683,6 +685,7 @@ class LokiSnodeAPI {
 
       return swarmNodes;
     } catch (e) {
+      log.error('getSwarmNodesForPubKey expection: ', e);
       throw new window.textsecure.ReplayableError({
         message: 'Could not get conversation',
       });

--- a/js/modules/metadata/SecretSessionCipher.js
+++ b/js/modules/metadata/SecretSessionCipher.js
@@ -255,27 +255,15 @@ function _createUnidentifiedSenderMessageContent(
 }
 
 SecretSessionCipher.prototype = {
-  // public byte[] encrypt(
-  //   SignalProtocolAddress destinationAddress,
-  //   SenderCertificate senderCertificate,
-  //   byte[] paddedPlaintext
-  // )
-  async encrypt(
-    destinationAddress,
-    senderCertificate,
-    paddedPlaintext,
-    cipher
-  ) {
+  async encrypt(destinationPubkey, senderCertificate, innerEncryptedMessage) {
     // Capture this.xxx variables to replicate Java's implicit this syntax
-    const signalProtocolStore = this.storage;
     const _calculateEphemeralKeys = this._calculateEphemeralKeys.bind(this);
     const _encryptWithSecretKeys = this._encryptWithSecretKeys.bind(this);
     const _calculateStaticKeys = this._calculateStaticKeys.bind(this);
 
-    const message = await cipher.encrypt(paddedPlaintext);
-    const ourIdentity = await signalProtocolStore.getIdentityKeyPair();
+    const ourIdentity = await this.storage.getIdentityKeyPair();
     const theirIdentity = dcodeIO.ByteBuffer.wrap(
-      destinationAddress.getName(),
+      destinationPubkey,
       'hex'
     ).toArrayBuffer();
 
@@ -306,9 +294,9 @@ SecretSessionCipher.prototype = {
       staticSalt
     );
     const content = _createUnidentifiedSenderMessageContent(
-      message.type,
+      innerEncryptedMessage.type,
       senderCertificate,
-      fromEncodedBinaryToArrayBuffer(message.body)
+      fromEncodedBinaryToArrayBuffer(innerEncryptedMessage.body)
     );
     const messageBytes = await _encryptWithSecretKeys(
       staticKeys.cipherKey,

--- a/libtextsecure/http-resources.js
+++ b/libtextsecure/http-resources.js
@@ -83,6 +83,14 @@
       }
     };
 
+    this.pollForAdditionalId = async groupId => {
+      await server.pollForGroupId(groupId, messages => {
+        messages.forEach(m => {
+          this.handleMessage(m.data, { conversationId: m.conversationId });
+        });
+      });
+    };
+
     this.pollServer = async () => {
       // bg.connect calls mr connect after storage system is ready
       window.log.info('http-resource pollServer start');
@@ -95,7 +103,9 @@
           messages => {
             connected = true;
             messages.forEach(message => {
-              this.handleMessage(message.data);
+              this.handleMessage(message.data, {
+                conversationId: message.conversationId,
+              });
             });
           }
         );

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -19,6 +19,7 @@
 /* global WebAPI: false */
 /* global ConversationController: false */
 /* global Signal: false */
+/* global log: false */
 
 /* eslint-disable more/no-then */
 /* eslint-disable no-unreachable */
@@ -170,6 +171,11 @@ MessageReceiver.prototype.extend({
       this.calledClose
     );
   },
+
+  pollForAdditionalId(id) {
+    this.httpPollingResource.pollForAdditionalId(id);
+  },
+
   handleRequest(request, options) {
     const { onSuccess, onFailure } = options;
     this.incoming = this.incoming || [];
@@ -189,11 +195,32 @@ MessageReceiver.prototype.extend({
     }
 
     const promise = Promise.resolve(request.body.toArrayBuffer()) // textsecure.crypto
-      .then(plaintext => {
+      .then(plaintextImmutable => {
+        let plaintext = plaintextImmutable;
+
         const envelope = textsecure.protobuf.Envelope.decode(plaintext);
         // After this point, decoding errors are not the server's
         //   fault, and we should handle them gracefully and tell the
         //   user they received an invalid message
+
+        // The message is for a medium size group
+        if (options.conversationId) {
+          const ourNumber = textsecure.storage.user.getNumber();
+          const senderIdentity = envelope.source;
+
+          if (senderIdentity === ourNumber) {
+            // Ignoring our own message
+            return request.respond(200, 'OK');
+          }
+
+          // Sender identity will be lost if we load from cache, because
+          // plaintext (and protobuf.Envelope) does not have that field...
+          envelope.source = options.conversationId;
+          plaintext = textsecure.protobuf.Envelope.encode(
+            envelope
+          ).toArrayBuffer();
+          envelope.senderIdentity = senderIdentity;
+        }
 
         if (this.isBlocked(envelope.source)) {
           return request.respond(200, 'OK');
@@ -334,6 +361,7 @@ MessageReceiver.prototype.extend({
       envelope.id = envelope.serverGuid || item.id;
       envelope.source = envelope.source || item.source;
       envelope.sourceDevice = envelope.sourceDevice || item.sourceDevice;
+      envelope.senderIdentity = envelope.senderIdentity || item.senderIdentity;
       envelope.serverTimestamp =
         envelope.serverTimestamp || item.serverTimestamp;
       envelope.preKeyBundleMessage =
@@ -447,6 +475,11 @@ MessageReceiver.prototype.extend({
       timestamp: Date.now(),
       attempts: 1,
     };
+
+    if (envelope.senderIdentity) {
+      data.senderIdentity = envelope.senderIdentity;
+    }
+
     return textsecure.storage.unprocessed.add(data);
   },
   async updateCache(envelope, plaintext) {
@@ -462,6 +495,11 @@ MessageReceiver.prototype.extend({
     item.source = envelope.source;
     item.sourceDevice = envelope.sourceDevice;
     item.serverTimestamp = envelope.serverTimestamp;
+
+    // For medium-size closed groups
+    if (envelope.senderIdentity) {
+      item.senderIdentity = envelope.senderIdentity;
+    }
 
     if (item.version === 2) {
       item.decrypted = await MessageReceiver.arrayBufferToStringBase64(
@@ -599,6 +637,67 @@ MessageReceiver.prototype.extend({
 
     return plaintext;
   },
+  async postDecrypt(envelope, plaintext) {
+    const { isMe, isBlocked } = plaintext || {};
+    if (isMe || isBlocked) {
+      this.removeFromCache(envelope);
+      return null;
+    }
+
+    let conversation;
+    try {
+      conversation = await window.ConversationController.getOrCreateAndWait(
+        envelope.source,
+        'private'
+      );
+    } catch (e) {
+      window.log.info('Error getting conversation: ', envelope.source);
+    }
+
+    // Type here can actually be UNIDENTIFIED_SENDER even if
+    // the underlying message is FRIEND_REQUEST
+    if (envelope.type !== textsecure.protobuf.Envelope.Type.FRIEND_REQUEST) {
+      // If we got here there is a valid session, which meants friend request
+      // is complete (if it wasn't already)
+      if (conversation) {
+        const isFriendRequestAccept = await conversation.onFriendRequestAccepted();
+        if (isFriendRequestAccept) {
+          await conversation.notifyFriendRequest(envelope.source, 'accepted');
+        }
+      }
+    }
+
+    this.updateCache(envelope, plaintext).catch(error => {
+      window.log.error(
+        'decrypt failed to save decrypted message contents to cache:',
+        error && error.stack ? error.stack : error
+      );
+    });
+
+    return plaintext;
+  },
+  async decryptForMediumGroup(envelope, ciphertextObj) {
+    const groupId = envelope.source;
+
+    // const identity = await window.Signal.Data.getIdentityKeyById(groupId);
+    // const secretKey = identity.secretKey; // TODO: use this for decryption!
+
+    const { senderIdentity } = envelope;
+
+    const {
+      ciphertext,
+      keyIdx,
+    } = textsecure.protobuf.MediumGroupCiphertext.decode(ciphertextObj);
+
+    const plaintext = await window.SenderKeyAPI.decryptWithSenderKey(
+      ciphertext,
+      keyIdx,
+      groupId,
+      senderIdentity
+    );
+
+    return plaintext;
+  },
   async decrypt(envelope, ciphertext) {
     let promise;
 
@@ -626,6 +725,9 @@ MessageReceiver.prototype.extend({
         promise = lokiSessionCipher
           .decryptWhisperMessage(ciphertext)
           .then(this.unpad);
+        break;
+      case textsecure.protobuf.Envelope.Type.MEDIUM_GROUP_CIPHERTEXT:
+        promise = this.decryptForMediumGroup(envelope, ciphertext);
         break;
       case textsecure.protobuf.Envelope.Type.FRIEND_REQUEST: {
         window.log.info('friend-request message from ', envelope.source);
@@ -731,50 +833,7 @@ MessageReceiver.prototype.extend({
     }
 
     return promise
-      .then(async plaintext => {
-        const { isMe, isBlocked } = plaintext || {};
-        if (isMe || isBlocked) {
-          this.removeFromCache(envelope);
-          return null;
-        }
-
-        let conversation;
-        try {
-          conversation = await window.ConversationController.getOrCreateAndWait(
-            envelope.source,
-            'private'
-          );
-        } catch (e) {
-          window.log.info('Error getting conversation: ', envelope.source);
-        }
-
-        // Type here can actually be UNIDENTIFIED_SENDER even if
-        // the underlying message is FRIEND_REQUEST
-        if (
-          envelope.type !== textsecure.protobuf.Envelope.Type.FRIEND_REQUEST
-        ) {
-          // If we got here there is a valid session, which meants friend request
-          // is complete (if it wasn't already)
-          if (conversation) {
-            const isFriendRequestAccept = await conversation.onFriendRequestAccepted();
-            if (isFriendRequestAccept) {
-              await conversation.notifyFriendRequest(
-                envelope.source,
-                'accepted'
-              );
-            }
-          }
-        }
-
-        this.updateCache(envelope, plaintext).catch(error => {
-          window.log.error(
-            'decrypt failed to save decrypted message contents to cache:',
-            error && error.stack ? error.stack : error
-          );
-        });
-
-        return plaintext;
-      })
+      .then(plaintext => this.postDecrypt(envelope, plaintext))
       .catch(error => {
         let errorToThrow = error;
 
@@ -1115,155 +1174,253 @@ MessageReceiver.prototype.extend({
 
     await conversation.setLokiProfile(newProfile);
   },
-  handleDataMessage(envelope, msg) {
+
+  async handleMediumGroupUpdate(envelope, groupUpdate) {
+    const {
+      groupId,
+      groupSecretKey,
+      senderKey,
+      members,
+      groupName,
+    } = groupUpdate;
+
+    const convoExists = window.ConversationController.get(groupId, 'group');
+
+    if (convoExists) {
+      // If the group already exists, check that `members` is empty,
+      // and if so, it is sender key message
+
+      // TODO: introduce TYPE into this message instead?
+      if (!members || !members.length) {
+        log.info('[sender key] got a new sender key from:', envelope.source);
+
+        // We probably don't need to await here
+        await window.SenderKeyAPI.saveSenderKeys(
+          groupId,
+          envelope.source,
+          senderKey
+        );
+
+        this.removeFromCache(envelope);
+        return;
+      }
+
+      log.error(`Conversation for groupId ${groupId} already exists`);
+    }
+
+    const convo = await window.ConversationController.getOrCreateAndWait(
+      groupId,
+      'group'
+    );
+    convo.set('is_medium_group', true);
+    convo.set('active_at', Date.now());
+    convo.set('name', groupName);
+
+    await window.Signal.Data.createOrUpdateIdentityKey({
+      id: groupId,
+      secretKey: groupSecretKey,
+    });
+
+    // Save sender's key
+    await window.SenderKeyAPI.saveSenderKeys(
+      groupId,
+      envelope.source,
+      senderKey
+    );
+
+    // TODO: Check that we are even a part of this group?
+    const ourIdentity = await textsecure.storage.user.getNumber();
+
+    const ownSenderKey = await window.SenderKeyAPI.createSenderKeyForGroup(
+      groupId,
+      ourIdentity
+    );
+
+    {
+      // TODO: Send own key to every member
+
+      const otherMembers = _.without(members, ourIdentity);
+
+      const proto = new textsecure.protobuf.DataMessage();
+
+      // We reuse the same message type for sender keys
+      const update = new textsecure.protobuf.MediumGroupUpdate();
+      update.groupId = groupId;
+      update.senderKey = ownSenderKey;
+
+      proto.mediumGroupUpdate = update;
+
+      // TODO: send to our linked devices too?
+
+      // Don't need to await here
+
+      // TODO: Some of the members might not have a session with us, so
+      // we should send a session request
+
+      textsecure.messaging.updateMediumGroup(otherMembers, proto);
+    }
+
+    // Subscribe to this group
+    this.pollForAdditionalId(groupId);
+
+    // All further messages (maybe rather than 'control' messages) should come to this group's swarm
+
+    this.removeFromCache(envelope);
+  },
+  async handleDataMessage(envelope, msg) {
     window.log.info('data message from', this.getEnvelopeId(envelope));
-    let p = Promise.resolve();
+
+    if (msg.mediumGroupUpdate) {
+      this.handleMediumGroupUpdate(envelope, msg.mediumGroupUpdate);
+      // TODO: investigate the meaning of this return value
+      return true;
+    }
+
     // eslint-disable-next-line no-bitwise
     if (msg.flags & textsecure.protobuf.DataMessage.Flags.END_SESSION) {
-      p = this.handleEndSession(envelope.source);
+      await this.handleEndSession(envelope.source);
     }
-    return p.then(() =>
-      this.processDecrypted(envelope, msg).then(async message => {
-        const groupId = message.group && message.group.id;
-        const isBlocked = this.isGroupBlocked(groupId);
-        const ourPubKey = textsecure.storage.user.getNumber();
-        const isMe = envelope.source === ourPubKey;
-        const conversation = window.ConversationController.get(envelope.source);
-        const isLeavingGroup = Boolean(
-          message.group &&
-            message.group.type === textsecure.protobuf.GroupContext.Type.QUIT
+
+    const message = await this.processDecrypted(envelope, msg);
+
+    const groupId = message.group && message.group.id;
+    const isBlocked = this.isGroupBlocked(groupId);
+    const ourPubKey = textsecure.storage.user.getNumber();
+    const isMe = envelope.source === ourPubKey;
+    const conversation = window.ConversationController.get(envelope.source);
+    const isLeavingGroup = Boolean(
+      message.group &&
+        message.group.type === textsecure.protobuf.GroupContext.Type.QUIT
+    );
+    const friendRequest =
+      envelope.type === textsecure.protobuf.Envelope.Type.FRIEND_REQUEST;
+    const { UNPAIRING_REQUEST } = textsecure.protobuf.DataMessage.Flags;
+    // eslint-disable-next-line no-bitwise
+    const isUnpairingRequest = Boolean(message.flags & UNPAIRING_REQUEST);
+
+    if (!friendRequest && isUnpairingRequest) {
+      // TODO: move high-level pairing logic to libloki.multidevice.xx
+
+      const unpairingRequestIsLegit = async () => {
+        const isSecondary = textsecure.storage.get('isSecondaryDevice');
+        if (!isSecondary) {
+          return false;
+        }
+        const primaryPubKey = window.storage.get('primaryDevicePubKey');
+        // TODO: allow unpairing from any paired device?
+        if (envelope.source !== primaryPubKey) {
+          return false;
+        }
+
+        const primaryMapping = await lokiFileServerAPI.getUserDeviceMapping(
+          primaryPubKey
         );
-        const friendRequest =
-          envelope.type === textsecure.protobuf.Envelope.Type.FRIEND_REQUEST;
-        const { UNPAIRING_REQUEST } = textsecure.protobuf.DataMessage.Flags;
-        // eslint-disable-next-line no-bitwise
-        const isUnpairingRequest = Boolean(message.flags & UNPAIRING_REQUEST);
 
-        if (!friendRequest && isUnpairingRequest) {
-          // TODO: move high-level pairing logic to libloki.multidevice.xx
-
-          const unpairingRequestIsLegit = async () => {
-            const isSecondary = textsecure.storage.get('isSecondaryDevice');
-            if (!isSecondary) {
-              return false;
-            }
-            const primaryPubKey = window.storage.get('primaryDevicePubKey');
-            // TODO: allow unpairing from any paired device?
-            if (envelope.source !== primaryPubKey) {
-              return false;
-            }
-
-            const primaryMapping = await lokiFileServerAPI.getUserDeviceMapping(
-              primaryPubKey
-            );
-
-            // If we don't have a mapping on the primary then we have been unlinked
-            if (!primaryMapping) {
-              return true;
-            }
-
-            // We expect the primary device to have updated its mapping
-            // before sending the unpairing request
-            const found = primaryMapping.authorisations.find(
-              authorisation => authorisation.secondaryDevicePubKey === ourPubKey
-            );
-
-            // our pubkey should NOT be in the primary device mapping
-            return !found;
-          };
-
-          const legit = await unpairingRequestIsLegit();
-
-          this.removeFromCache(envelope);
-
-          if (legit) {
-            // remove our device mapping annotations from file server
-            await lokiFileServerAPI.clearOurDeviceMappingAnnotations();
-            // Delete the account and restart
-            try {
-              await window.Signal.Logs.deleteAll();
-              await window.Signal.Data.removeAll();
-              await window.Signal.Data.close();
-              await window.Signal.Data.removeDB();
-              await window.Signal.Data.removeOtherData();
-              // TODO generate an empty db with a flag
-              // to display a message about the unpairing
-              // after the app restarts
-            } catch (error) {
-              window.log.error(
-                'Something went wrong deleting all data:',
-                error && error.stack ? error.stack : error
-              );
-            }
-            window.restart();
-          }
+        // If we don't have a mapping on the primary then we have been unlinked
+        if (!primaryMapping) {
+          return true;
         }
 
-        // Check if we need to update any profile names
-        if (!isMe && conversation) {
-          if (message.profile) {
-            await this.updateProfile(
-              conversation,
-              message.profile,
-              message.profileKey
-            );
-          }
-        }
+        // We expect the primary device to have updated its mapping
+        // before sending the unpairing request
+        const found = primaryMapping.authorisations.find(
+          authorisation => authorisation.secondaryDevicePubKey === ourPubKey
+        );
 
-        // If we got a friend request message or
-        //  if we're not friends with the current user that sent this private message
-        // Check to see if we need to auto accept their friend request
-        const isGroupMessage = !!groupId;
-        if (friendRequest || (!isGroupMessage && !conversation.isFriend())) {
-          if (isMe) {
-            window.log.info('refusing to add a friend request to ourselves');
-            throw new Error('Cannot add a friend request for ourselves!');
-          } else {
-            const senderPubKey = envelope.source;
-            // fetch the device mapping from the server
-            const deviceMapping = await lokiFileServerAPI.getUserDeviceMapping(
-              senderPubKey
-            );
-            // auto-accept friend request if the device is paired to one of our friend
-            const autoAccepted = await this.handleSecondaryDeviceFriendRequest(
-              senderPubKey,
-              deviceMapping
-            );
-            if (autoAccepted) {
-              // sending a message back = accepting friend request
-              // Directly setting friend request status to skip the pending state
-              await conversation.setFriendRequestStatus(
-                window.friends.friendRequestStatusEnum.friends
-              );
-              window.libloki.api.sendBackgroundMessage(envelope.source);
-              return this.removeFromCache(envelope);
-            }
-          }
-        }
+        // our pubkey should NOT be in the primary device mapping
+        return !found;
+      };
 
-        if (groupId && isBlocked && !(isMe && isLeavingGroup)) {
-          window.log.warn(
-            `Message ${this.getEnvelopeId(
-              envelope
-            )} ignored; destined for blocked group`
+      const legit = await unpairingRequestIsLegit();
+
+      this.removeFromCache(envelope);
+
+      if (legit) {
+        // remove our device mapping annotations from file server
+        await lokiFileServerAPI.clearOurDeviceMappingAnnotations();
+        // Delete the account and restart
+        try {
+          await window.Signal.Logs.deleteAll();
+          await window.Signal.Data.removeAll();
+          await window.Signal.Data.close();
+          await window.Signal.Data.removeDB();
+          await window.Signal.Data.removeOtherData();
+          // TODO generate an empty db with a flag
+          // to display a message about the unpairing
+          // after the app restarts
+        } catch (error) {
+          window.log.error(
+            'Something went wrong deleting all data:',
+            error && error.stack ? error.stack : error
           );
+        }
+        window.restart();
+      }
+    }
+
+    // Check if we need to update any profile names
+    if (!isMe && conversation) {
+      if (message.profile) {
+        await this.updateProfile(
+          conversation,
+          message.profile,
+          message.profileKey
+        );
+      }
+    }
+
+    // If we got a friend request message or
+    //  if we're not friends with the current user that sent this private message
+    // Check to see if we need to auto accept their friend request
+    const isGroupMessage = !!groupId;
+    if (friendRequest || (!isGroupMessage && !conversation.isFriend())) {
+      if (isMe) {
+        window.log.info('refusing to add a friend request to ourselves');
+        throw new Error('Cannot add a friend request for ourselves!');
+      } else {
+        const senderPubKey = envelope.source;
+        // fetch the device mapping from the server
+        const deviceMapping = await lokiFileServerAPI.getUserDeviceMapping(
+          senderPubKey
+        );
+        // auto-accept friend request if the device is paired to one of our friend
+        const autoAccepted = await this.handleSecondaryDeviceFriendRequest(
+          senderPubKey,
+          deviceMapping
+        );
+        if (autoAccepted) {
+          // sending a message back = accepting friend request
+          // Directly setting friend request status to skip the pending state
+          await conversation.setFriendRequestStatus(
+            window.friends.friendRequestStatusEnum.friends
+          );
+          window.libloki.api.sendBackgroundMessage(envelope.source);
           return this.removeFromCache(envelope);
         }
+      }
+    }
 
-        const ev = new Event('message');
-        ev.confirm = this.removeFromCache.bind(this, envelope);
-        ev.data = {
-          friendRequest,
-          source: envelope.source,
-          sourceDevice: envelope.sourceDevice,
-          timestamp: envelope.timestamp.toNumber(),
-          receivedAt: envelope.receivedAt,
-          unidentifiedDeliveryReceived: envelope.unidentifiedDeliveryReceived,
-          message,
-        };
-        return this.dispatchAndWait(ev);
-      })
-    );
+    if (groupId && isBlocked && !(isMe && isLeavingGroup)) {
+      window.log.warn(
+        `Message ${this.getEnvelopeId(
+          envelope
+        )} ignored; destined for blocked group`
+      );
+      return this.removeFromCache(envelope);
+    }
+
+    const ev = new Event('message');
+    ev.confirm = this.removeFromCache.bind(this, envelope);
+    ev.data = {
+      friendRequest,
+      source: envelope.source,
+      sourceDevice: envelope.sourceDevice,
+      timestamp: envelope.timestamp.toNumber(),
+      receivedAt: envelope.receivedAt,
+      unidentifiedDeliveryReceived: envelope.unidentifiedDeliveryReceived,
+      message,
+    };
+    return this.dispatchAndWait(ev);
   },
   handleLegacyMessage(envelope) {
     return this.decrypt(envelope, envelope.legacyMessage).then(plaintext => {
@@ -1278,19 +1435,16 @@ MessageReceiver.prototype.extend({
     const message = textsecure.protobuf.DataMessage.decode(plaintext);
     return this.handleDataMessage(envelope, message);
   },
-  handleContentMessage(envelope) {
-    return this.decrypt(envelope, envelope.content).then(plaintext => {
-      if (!plaintext) {
-        window.log.warn('handleContentMessage: plaintext was falsey');
-        return null;
-      } else if (
-        plaintext instanceof ArrayBuffer &&
-        plaintext.byteLength === 0
-      ) {
-        return null;
-      }
-      return this.innerHandleContentMessage(envelope, plaintext);
-    });
+  async handleContentMessage(envelope) {
+    const plaintext = await this.decrypt(envelope, envelope.content);
+
+    if (!plaintext) {
+      window.log.warn('handleContentMessage: plaintext was falsey');
+      return null;
+    } else if (plaintext instanceof ArrayBuffer && plaintext.byteLength === 0) {
+      return null;
+    }
+    return this.innerHandleContentMessage(envelope, plaintext);
   },
   async innerHandleContentMessage(envelope, plaintext) {
     const content = textsecure.protobuf.Content.decode(plaintext);
@@ -1855,6 +2009,10 @@ textsecure.MessageReceiver = function MessageReceiverWrapper(
   );
 
   this.downloadAttachment = messageReceiver.downloadAttachment.bind(
+    messageReceiver
+  );
+
+  this.pollForAdditionalId = messageReceiver.pollForAdditionalId.bind(
     messageReceiver
   );
   this.stopProcessing = messageReceiver.stopProcessing.bind(messageReceiver);

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -7,6 +7,7 @@
   StringView,
   lokiMessageAPI,
   i18n,
+  log
 */
 
 /* eslint-disable more/no-then */
@@ -29,6 +30,82 @@ const getTTLForType = type => {
       return (window.getMessageTTL() || 24) * 60 * 60 * 1000; // 1 day default for any other message
   }
 };
+
+function _getPaddedMessageLength(messageLength) {
+  const messageLengthWithTerminator = messageLength + 1;
+  let messagePartCount = Math.floor(messageLengthWithTerminator / 160);
+
+  if (messageLengthWithTerminator % 160 !== 0) {
+    messagePartCount += 1;
+  }
+
+  return messagePartCount * 160;
+}
+
+function _convertMessageToText(messageBuffer) {
+  const plaintext = new Uint8Array(
+    _getPaddedMessageLength(messageBuffer.byteLength + 1) - 1
+  );
+  plaintext.set(new Uint8Array(messageBuffer));
+  plaintext[messageBuffer.byteLength] = 0x80;
+
+  return plaintext;
+}
+
+function _getPlaintext(messageBuffer) {
+  return _convertMessageToText(messageBuffer);
+}
+
+function wrapInWebsocketMessage(outgoingObject, timestamp) {
+  const source =
+    outgoingObject.type ===
+    textsecure.protobuf.Envelope.Type.UNIDENTIFIED_SENDER
+      ? null
+      : outgoingObject.ourKey;
+
+  const messageEnvelope = new textsecure.protobuf.Envelope({
+    type: outgoingObject.type,
+    source,
+    sourceDevice: outgoingObject.sourceDevice,
+    timestamp,
+    content: outgoingObject.content,
+  });
+  const requestMessage = new textsecure.protobuf.WebSocketRequestMessage({
+    id: new Uint8Array(libsignal.crypto.getRandomBytes(1))[0], // random ID for now
+    verb: 'PUT',
+    path: '/api/v1/message',
+    body: messageEnvelope.encode().toArrayBuffer(),
+  });
+  const websocketMessage = new textsecure.protobuf.WebSocketMessage({
+    type: textsecure.protobuf.WebSocketMessage.Type.REQUEST,
+    request: requestMessage,
+  });
+  const bytes = new Uint8Array(websocketMessage.encode().toArrayBuffer());
+  return bytes;
+}
+
+function getStaleDeviceIdsForNumber(number) {
+  return textsecure.storage.protocol.getDeviceIds(number).then(deviceIds => {
+    if (deviceIds.length === 0) {
+      return [1];
+    }
+    const updateDevices = [];
+    return Promise.all(
+      deviceIds.map(deviceId => {
+        const address = new libsignal.SignalProtocolAddress(number, deviceId);
+        const sessionCipher = new libsignal.SessionCipher(
+          textsecure.storage.protocol,
+          address
+        );
+        return sessionCipher.hasOpenSession().then(hasSession => {
+          if (!hasSession) {
+            updateDevices.push(deviceId);
+          }
+        });
+      })
+    ).then(() => updateDevices);
+  });
+}
 
 function OutgoingMessage(
   server,
@@ -66,11 +143,13 @@ function OutgoingMessage(
     messageType,
     isPing,
     isPublic,
+    isMediumGroup,
     publicSendData,
   } =
     options || {};
   this.numberInfo = numberInfo;
   this.isPublic = isPublic;
+  this.isMediumGroup = !!isMediumGroup;
   this.isGroup = !!(
     this.message &&
     this.message.dataMessage &&
@@ -115,11 +194,12 @@ OutgoingMessage.prototype = {
     this.errors[this.errors.length] = error;
     this.numberCompleted();
   },
-  reloadDevicesAndSend(number, recurse) {
+  reloadDevicesAndSend(primaryPubKey) {
     const ourNumber = textsecure.storage.user.getNumber();
-    return () =>
+
+    return (
       libloki.storage
-        .getAllDevicePubKeysForPrimaryPubKey(number)
+        .getAllDevicePubKeysForPrimaryPubKey(primaryPubKey)
         // Don't send to ourselves
         .then(devicesPubKeys =>
           devicesPubKeys.filter(pubKey => pubKey !== ourNumber)
@@ -127,10 +207,11 @@ OutgoingMessage.prototype = {
         .then(devicesPubKeys => {
           if (devicesPubKeys.length === 0) {
             // eslint-disable-next-line no-param-reassign
-            devicesPubKeys = [number];
+            devicesPubKeys = [primaryPubKey];
           }
-          return this.doSendMessage(number, devicesPubKeys, recurse);
-        });
+          return this.doSendMessage(primaryPubKey, devicesPubKeys);
+        })
+    );
   },
 
   getKeysForNumber(number, updateDevices) {
@@ -243,58 +324,8 @@ OutgoingMessage.prototype = {
     }
   },
 
-  getPaddedMessageLength(messageLength) {
-    const messageLengthWithTerminator = messageLength + 1;
-    let messagePartCount = Math.floor(messageLengthWithTerminator / 160);
-
-    if (messageLengthWithTerminator % 160 !== 0) {
-      messagePartCount += 1;
-    }
-
-    return messagePartCount * 160;
-  },
-  convertMessageToText(messageBuffer) {
-    const plaintext = new Uint8Array(
-      this.getPaddedMessageLength(messageBuffer.byteLength + 1) - 1
-    );
-    plaintext.set(new Uint8Array(messageBuffer));
-    plaintext[messageBuffer.byteLength] = 0x80;
-
-    return plaintext;
-  },
-  getPlaintext(messageBuffer) {
-    return this.convertMessageToText(messageBuffer);
-  },
-  async wrapInWebsocketMessage(outgoingObject) {
-    const source =
-      outgoingObject.type ===
-      textsecure.protobuf.Envelope.Type.UNIDENTIFIED_SENDER
-        ? null
-        : outgoingObject.ourKey;
-
-    const messageEnvelope = new textsecure.protobuf.Envelope({
-      type: outgoingObject.type,
-      source,
-      sourceDevice: outgoingObject.sourceDevice,
-      timestamp: this.timestamp,
-      content: outgoingObject.content,
-    });
-    const requestMessage = new textsecure.protobuf.WebSocketRequestMessage({
-      id: new Uint8Array(libsignal.crypto.getRandomBytes(1))[0], // random ID for now
-      verb: 'PUT',
-      path: '/api/v1/message',
-      body: messageEnvelope.encode().toArrayBuffer(),
-    });
-    const websocketMessage = new textsecure.protobuf.WebSocketMessage({
-      type: textsecure.protobuf.WebSocketMessage.Type.REQUEST,
-      request: requestMessage,
-    });
-    const bytes = new Uint8Array(websocketMessage.encode().toArrayBuffer());
-    return bytes;
-  },
-
   async buildMessage(devicePubKey) {
-    const updatedDevices = await this.getStaleDeviceIdsForNumber(devicePubKey);
+    const updatedDevices = await getStaleDeviceIdsForNumber(devicePubKey);
     const keysFound = await this.getKeysForNumber(devicePubKey, updatedDevices);
 
     let isMultiDeviceRequest = false;
@@ -375,7 +406,7 @@ OutgoingMessage.prototype = {
       messageBuffer = this.message.toArrayBuffer();
     }
 
-    const plaintext = this.getPlaintext(messageBuffer);
+    const plaintext = _getPlaintext(messageBuffer);
 
     // No limit on message keys if we're communicating with our other devices
     // FIXME options not used at all; if (ourPubkey === number) {
@@ -429,10 +460,11 @@ OutgoingMessage.prototype = {
       );
     }
 
+    const innerCiphertext = await sessionCipher.encrypt(plaintext);
+
     const secretSessionCipher = new window.Signal.Metadata.SecretSessionCipher(
       textsecure.storage.protocol
     );
-    // ciphers[address.getDeviceId()] = secretSessionCipher;
 
     const senderCert = new textsecure.protobuf.SenderCertificate();
 
@@ -440,10 +472,9 @@ OutgoingMessage.prototype = {
     senderCert.senderDevice = deviceId;
 
     const ciphertext = await secretSessionCipher.encrypt(
-      address,
+      address.getName(),
       senderCert,
-      plaintext,
-      sessionCipher
+      innerCiphertext
     );
     const type = textsecure.protobuf.Envelope.Type.UNIDENTIFIED_SENDER;
     const content = window.Signal.Crypto.arrayBufferToBase64(ciphertext);
@@ -460,20 +491,74 @@ OutgoingMessage.prototype = {
     };
   },
   // Send a message to a public group
-  sendPublicMessage(number) {
-    return this.transmitMessage(
-      number,
-      this.message.dataMessage,
-      this.timestamp,
-      0 // ttl
-    )
-      .then(() => {
-        this.successfulNumbers[this.successfulNumbers.length] = number;
-        this.numberCompleted();
-      })
-      .catch(error => {
-        throw error;
-      });
+  async sendPublicMessage(number) {
+    if (this.isPublic) {
+      await this.transmitMessage(
+        number,
+        this.message.dataMessage,
+        this.timestamp,
+        0 // ttl
+      );
+
+      this.successfulNumbers[this.successfulNumbers.length] = number;
+      this.numberCompleted();
+    }
+  },
+
+  async sendMediumGroupMessage(groupId) {
+    const ttl = getTTLForType(this.messageType);
+
+    const plaintext = this.message.toArrayBuffer();
+
+    const ourIdentity = textsecure.storage.user.getNumber();
+
+    const {
+      ciphertext,
+      keyIdx,
+    } = await window.SenderKeyAPI.encryptWithSenderKey(
+      plaintext,
+      groupId,
+      ourIdentity
+    );
+
+    if (!ciphertext) {
+      log.error('could not encrypt for medium group');
+      return;
+    }
+
+    // We should include ciphertext idx in the message
+    const content = new textsecure.protobuf.MediumGroupCiphertext({
+      ciphertext,
+      keyIdx,
+    });
+
+    log.debug(
+      'Group ciphertext: ',
+      window.Signal.Crypto.arrayBufferToBase64(ciphertext)
+    );
+
+    const outgoingObject = {
+      type: textsecure.protobuf.Envelope.Type.MEDIUM_GROUP_CIPHERTEXT,
+      ttl,
+      ourKey: ourIdentity,
+      sourceDevice: 1,
+      content: content.encode().toArrayBuffer(),
+      isFriendRequest: false,
+      isSessionRequest: false,
+    };
+
+    // TODO: Rather than using sealed sender, we just generate a key pair, perform an ECDH against
+    // the group's public key and encrypt using the derived key
+
+    const socketMessage = wrapInWebsocketMessage(
+      outgoingObject,
+      this.timestamp
+    );
+
+    await this.transmitMessage(groupId, socketMessage, this.timestamp, ttl);
+
+    this.successfulNumbers[this.successfulNumbers.length] = groupId;
+    this.numberCompleted();
   },
   // Send a message to a private group or a session chat (one to one)
   async sendSessionMessage(outgoingObjects) {
@@ -489,7 +574,10 @@ OutgoingMessage.prototype = {
         isSessionRequest,
       } = outgoingObject;
       try {
-        const socketMessage = await this.wrapInWebsocketMessage(outgoingObject);
+        const socketMessage = wrapInWebsocketMessage(
+          outgoingObject,
+          this.timestamp
+        );
         await this.transmitMessage(
           destination,
           socketMessage,
@@ -526,45 +614,23 @@ OutgoingMessage.prototype = {
     return this.encryptMessage(clearMessage);
   },
   // eslint-disable-next-line no-unused-vars
-  doSendMessage(number, devicesPubKeys, recurse) {
+  async doSendMessage(primaryPubKey, devicesPubKeys) {
     if (this.isPublic) {
-      return this.sendPublicMessage(number);
+      await this.sendPublicMessage(primaryPubKey);
+      return;
     }
     this.numbers = devicesPubKeys;
 
-    return Promise.all(
-      devicesPubKeys.map(devicePubKey => this.buildAndEncrypt(devicePubKey))
-    )
-      .then(outgoingObjects => this.sendSessionMessage(outgoingObjects))
-      .catch(error => {
-        // TODO(loki): handle http errors properly
-        // - retry later if 400
-        // - ignore if 409 (conflict) means the hash already exists
-        throw error;
-      });
-  },
+    if (this.isMediumGroup) {
+      await this.sendMediumGroupMessage(primaryPubKey);
+      return;
+    }
 
-  getStaleDeviceIdsForNumber(number) {
-    return textsecure.storage.protocol.getDeviceIds(number).then(deviceIds => {
-      if (deviceIds.length === 0) {
-        return [1];
-      }
-      const updateDevices = [];
-      return Promise.all(
-        deviceIds.map(deviceId => {
-          const address = new libsignal.SignalProtocolAddress(number, deviceId);
-          const sessionCipher = new libsignal.SessionCipher(
-            textsecure.storage.protocol,
-            address
-          );
-          return sessionCipher.hasOpenSession().then(hasSession => {
-            if (!hasSession) {
-              updateDevices.push(deviceId);
-            }
-          });
-        })
-      ).then(() => updateDevices);
-    });
+    const outgoingObjects = await Promise.all(
+      devicesPubKeys.map(pk => this.buildAndEncrypt(pk, primaryPubKey))
+    );
+
+    this.sendSessionMessage(outgoingObjects);
   },
 
   removeDeviceIdsForNumber(number, deviceIdsToRemove) {
@@ -586,7 +652,7 @@ OutgoingMessage.prototype = {
     } catch (e) {
       // do nothing
     }
-    return this.reloadDevicesAndSend(number, true)().catch(error => {
+    return this.reloadDevicesAndSend(number).catch(error => {
       conversation.resetPendingSend();
       if (error.message === 'Identity key changed') {
         // eslint-disable-next-line no-param-reassign

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -492,7 +492,6 @@ OutgoingMessage.prototype = {
   },
   // Send a message to a public group
   async sendPublicMessage(number) {
-    if (this.isPublic) {
       await this.transmitMessage(
         number,
         this.message.dataMessage,
@@ -502,7 +501,6 @@ OutgoingMessage.prototype = {
 
       this.successfulNumbers[this.successfulNumbers.length] = number;
       this.numberCompleted();
-    }
   },
 
   async sendMediumGroupMessage(groupId) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "start-prod-multi": "cross-env NODE_ENV=production NODE_APP_INSTANCE=devprod1 electron .",
     "start-swarm-test": "cross-env NODE_ENV=swarm-testing NODE_APP_INSTANCE=1 electron .",
     "start-swarm-test-2": "cross-env NODE_ENV=swarm-testing NODE_APP_INSTANCE=2 electron .",
+    "start-swarm-test-3": "cross-env NODE_ENV=swarm-testing NODE_APP_INSTANCE=3 electron .",
     "grunt": "grunt",
     "icon-gen": "electron-icon-maker --input=images/icon_1024.png --output=./build",
     "generate": "yarn icon-gen && yarn grunt",

--- a/preload.js
+++ b/preload.js
@@ -317,6 +317,8 @@ window.WebAPI = initializeWebAPI();
 window.seedNodeList = JSON.parse(config.seedNodeList);
 const LokiSnodeAPI = require('./js/modules/loki_snode_api');
 
+window.SenderKeyAPI = require('./js/modules/loki_sender_key_api');
+
 window.lokiSnodeAPI = new LokiSnodeAPI({
   serverUrl: config.serverUrl,
   localUrl: config.localUrl,

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -42,7 +42,13 @@ message Content {
 
 message MediumGroupCiphertext {
   optional bytes ciphertext = 1;
-  optional uint32 keyIdx = 2;
+  optional string source = 2;
+  optional uint32 keyIdx = 3;
+}
+
+message MediumGroupContent {
+  optional bytes ciphertext = 1;
+  optional bytes ephemeralKey = 2;
 }
 
 message MediumGroupUpdate {

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -12,6 +12,7 @@ message Envelope {
     PREKEY_BUNDLE = 3; //Used By Signal. DO NOT TOUCH! we don't use this at all.
     RECEIPT       = 5;
     UNIDENTIFIED_SENDER = 6;
+    MEDIUM_GROUP_CIPHERTEXT = 7;
     FRIEND_REQUEST = 101; // contains prekeys + message and is using simple encryption
   }
 
@@ -37,6 +38,24 @@ message Content {
   optional PreKeyBundleMessage preKeyBundleMessage = 101;
   optional LokiAddressMessage lokiAddressMessage = 102;
   optional PairingAuthorisationMessage pairingAuthorisation = 103;
+}
+
+message MediumGroupCiphertext {
+  optional bytes ciphertext = 1;
+  optional uint32 keyIdx = 2;
+}
+
+message MediumGroupUpdate {
+  optional string groupName = 1;
+  optional string groupId = 2; // should this be bytes?
+  optional string groupSecretKey = 3;
+  optional string senderKey = 4;
+  repeated string members = 5;
+}
+
+message SenderKeyUpdate {
+  optional string groupId = 1;
+  optional string senderKey = 2;
 }
 
 message LokiAddressMessage {
@@ -219,7 +238,8 @@ message DataMessage {
   repeated Contact            contact     = 9;
   repeated Preview            preview     = 10;
   optional LokiProfile        profile     = 101; // Loki: The profile of the current user
-  optional GroupInvitation groupInvitation = 102; // Loki: Invitation to a public chat
+  optional GroupInvitation    groupInvitation = 102; // Loki: Invitation to a public chat
+  optional MediumGroupUpdate  mediumGroupUpdate = 103; // Loki
 }
 
 message NullMessage {


### PR DESCRIPTION
This is not a complete implementation, but most of it is done and this PR is getting big.

Implemented:
- Polling for more than one id (group ids in addition to our identity)
- lastHash is now conversationId-aware
- Group creation and sender key management
- Messages with sender keys are correctly associated with the right conversation in GUI
- A brand new ratchet implementation for use with sender keys (different from Signal's in that it is missing the DH component impractical for groups)

For testing:
```
async function createMediumSizeGroup(groupName, members) { ... }
```
Example:
```
window.createMediumSizeGroup("GroupName", ["0531715c5f8476108b2481c9f42d62943417d795da96f0a7346644401294dba319", "05aaf884bef56a7d0dc044e2c8a330c4d0e2cb3e2cb785b6c169bc9c0beb0fcf21"])
```

Still missing:
- Multidevice support
- More robust sender key exchange (better interplay with session-request)
- Better error handling
