### PR TITLE
Update mainnet servers, stop using testnet port

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -15,11 +15,11 @@
     },
     {
       "ip": "storage.seed2.loki.network",
-      "port": "38157"
+      "port": "22023"
     },
     {
       "ip": "imaginary.stream",
-      "port": "38157"
+      "port": "22023"
     }
   ],
   "updatesEnabled": false,


### PR DESCRIPTION
Kee and I have confirmed mainnet port on `storage.seed2.loki.network` was fine since 6.x
imaginary.stream change Jason's approval:
https://discordapp.com/channels/408081923835953153/563594234632863754/685282143743901696