### PR TITLE
Handle typing and expiration messages when sending to group

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -417,13 +417,13 @@
         libsession
           .getMessageQueue()
           .sendUsingMultiDevice(device, typingMessage)
-          .ignore();
+          .catch(log.error);
       } else {
         // the recipients on the case of a group are found by the messageQueue using message.groupId
         libsession
           .getMessageQueue()
           .sendToGroup(typingMessage)
-          .ignore();
+          .catch(log.error);
       }
     },
 
@@ -1925,7 +1925,7 @@
       libsession
         .getMessageQueue()
         .sendToGroup(groupUpdateMessage)
-        .ignore();
+        .catch(log.error);
     },
 
     sendGroupInfo(recipient) {
@@ -1949,7 +1949,7 @@
         libsession
           .getMessageQueue()
           .send(recipientPubKey, groupUpdateMessage)
-          .ignore();
+          .catch(log.error);
       }
     },
 

--- a/test/models/conversations_test.js
+++ b/test/models/conversations_test.js
@@ -96,7 +96,7 @@ describe('Conversation', () => {
   it('adds conversation to message collection upon leaving group', async () => {
     const convo = new Whisper.ConversationCollection().add({
       type: 'group',
-      id: 'a random string',
+      id: '052d11d01e56d9bfc3d74115c33225a632321b509ac17a13fdeac71165d09b94ab',
     });
     await convo.leaveGroup();
     assert.notEqual(convo.messageCollection.length, 0);

--- a/ts/session/messages/outgoing/content/TypingMessage.ts
+++ b/ts/session/messages/outgoing/content/TypingMessage.ts
@@ -3,23 +3,26 @@ import { SignalService } from '../../../../protobuf';
 import { TextEncoder } from 'util';
 import { MessageParams } from '../Message';
 import { StringUtils } from '../../../utils';
+import { PubKey } from '../../../types';
 
 interface TypingMessageParams extends MessageParams {
   isTyping: boolean;
   typingTimestamp?: number;
-  groupId?: string;
+  groupId?: string | PubKey;
 }
 
 export class TypingMessage extends ContentMessage {
-  private readonly isTyping: boolean;
-  private readonly typingTimestamp?: number;
-  private readonly groupId?: string;
+  public readonly isTyping: boolean;
+  public readonly typingTimestamp?: number;
+  public readonly groupId?: PubKey;
 
   constructor(params: TypingMessageParams) {
     super({ timestamp: params.timestamp, identifier: params.identifier });
     this.isTyping = params.isTyping;
     this.typingTimestamp = params.typingTimestamp;
-    this.groupId = params.groupId;
+
+    const { groupId } = params;
+    this.groupId = groupId ? PubKey.cast(groupId) : undefined;
   }
 
   public ttl(): number {
@@ -41,7 +44,7 @@ export class TypingMessage extends ContentMessage {
     const typingMessage = new SignalService.TypingMessage();
     if (this.groupId) {
       typingMessage.groupId = new Uint8Array(
-        StringUtils.encode(this.groupId, 'utf8')
+        StringUtils.encode(this.groupId.key, 'utf8')
       );
     }
     typingMessage.action = action;

--- a/ts/session/messages/outgoing/content/data/ExpirationTimerUpdateMessage.ts
+++ b/ts/session/messages/outgoing/content/data/ExpirationTimerUpdateMessage.ts
@@ -3,23 +3,26 @@ import { SignalService } from '../../../../../protobuf';
 import { MessageParams } from '../../Message';
 import { StringUtils } from '../../../../utils';
 import { DataMessage } from './DataMessage';
+import { PubKey } from '../../../../types';
 
 interface ExpirationTimerUpdateMessageParams extends MessageParams {
-  groupId?: string;
+  groupId?: string | PubKey;
   expireTimer: number | null;
   profileKey?: Uint8Array;
 }
 
 export class ExpirationTimerUpdateMessage extends DataMessage {
-  private readonly groupId?: string;
-  private readonly expireTimer: number | null;
-  private readonly profileKey?: Uint8Array;
+  public readonly groupId?: PubKey;
+  public readonly expireTimer: number | null;
+  public readonly profileKey?: Uint8Array;
 
   constructor(params: ExpirationTimerUpdateMessageParams) {
     super({ timestamp: params.timestamp, identifier: params.identifier });
-    this.groupId = params.groupId;
     this.expireTimer = params.expireTimer;
     this.profileKey = params.profileKey;
+
+    const { groupId } = params;
+    this.groupId = groupId ? PubKey.cast(groupId) : undefined;
   }
 
   public ttl(): number {
@@ -32,7 +35,7 @@ export class ExpirationTimerUpdateMessage extends DataMessage {
     const groupMessage = new SignalService.GroupContext();
     if (this.groupId) {
       groupMessage.id = new Uint8Array(
-        StringUtils.encode(this.groupId, 'utf8')
+        StringUtils.encode(this.groupId.key, 'utf8')
       );
       groupMessage.type = SignalService.GroupContext.Type.DELIVER;
     }

--- a/ts/session/messages/outgoing/content/data/group/ClosedGroupMessage.ts
+++ b/ts/session/messages/outgoing/content/data/group/ClosedGroupMessage.ts
@@ -16,8 +16,7 @@ export abstract class ClosedGroupMessage extends DataMessage {
       timestamp: params.timestamp,
       identifier: params.identifier,
     });
-    const { groupId } = params;
-    this.groupId = typeof groupId === 'string' ? new PubKey(groupId) : groupId;
+    this.groupId = PubKey.cast(params.groupId);
   }
 
   public ttl(): number {

--- a/ts/session/messages/outgoing/content/data/index.ts
+++ b/ts/session/messages/outgoing/content/data/index.ts
@@ -3,3 +3,4 @@ export * from './DeviceUnlinkMessage';
 export * from './GroupInvitationMessage';
 export * from './ChatMessage';
 export * from './group';
+export * from './ExpirationTimerUpdateMessage';

--- a/ts/session/protocols/MultiDeviceProtocol.ts
+++ b/ts/session/protocols/MultiDeviceProtocol.ts
@@ -120,7 +120,7 @@ export class MultiDeviceProtocol {
   public static async getPairingAuthorisations(
     device: PubKey | string
   ): Promise<Array<PairingAuthorisation>> {
-    const pubKey = typeof device === 'string' ? new PubKey(device) : device;
+    const pubKey = PubKey.cast(device);
     await this.fetchPairingAuthorisationsIfNeeded(pubKey);
 
     return getPairingAuthorisationsFor(pubKey.key);
@@ -133,7 +133,7 @@ export class MultiDeviceProtocol {
   public static async removePairingAuthorisations(
     device: PubKey | string
   ): Promise<void> {
-    const pubKey = typeof device === 'string' ? new PubKey(device) : device;
+    const pubKey = PubKey.cast(device);
 
     return removePairingAuthorisationsFor(pubKey.key);
   }
@@ -146,7 +146,7 @@ export class MultiDeviceProtocol {
   public static async getAllDevices(
     user: PubKey | string
   ): Promise<Array<PubKey>> {
-    const pubKey = typeof user === 'string' ? new PubKey(user) : user;
+    const pubKey = PubKey.cast(user);
     const authorisations = await this.getPairingAuthorisations(pubKey);
     if (authorisations.length === 0) {
       return [pubKey];
@@ -170,7 +170,7 @@ export class MultiDeviceProtocol {
   public static async getPrimaryDevice(
     user: PubKey | string
   ): Promise<PrimaryPubKey> {
-    const pubKey = typeof user === 'string' ? new PubKey(user) : user;
+    const pubKey = PubKey.cast(user);
     const authorisations = await this.getPairingAuthorisations(pubKey);
     if (authorisations.length === 0) {
       return pubKey;
@@ -217,7 +217,7 @@ export class MultiDeviceProtocol {
    * @param device The device to check.
    */
   public static async isOurDevice(device: PubKey | string): Promise<boolean> {
-    const pubKey = typeof device === 'string' ? new PubKey(device) : device;
+    const pubKey = PubKey.cast(device);
     try {
       const ourDevices = await this.getOurDevices();
 

--- a/ts/session/sending/MessageQueue.ts
+++ b/ts/session/sending/MessageQueue.ts
@@ -6,6 +6,7 @@ import {
 import {
   ClosedGroupMessage,
   ContentMessage,
+  ExpirationTimerUpdateMessage,
   OpenGroupMessage,
   SessionRequestMessage,
   SyncMessage,
@@ -22,7 +23,6 @@ import { PubKey } from '../types';
 import { MessageSender } from '.';
 import { MultiDeviceProtocol, SessionProtocol } from '../protocols';
 import { UserUtil } from '../../util';
-import { ExpirationTimerUpdateMessage } from '../messages/outgoing/content/data/ExpirationTimerUpdateMessage';
 
 export class MessageQueue implements MessageQueueInterface {
   public readonly events: TypedEventEmitter<MessageQueueInterfaceEvents>;

--- a/ts/session/sending/MessageQueueInterface.ts
+++ b/ts/session/sending/MessageQueueInterface.ts
@@ -17,8 +17,8 @@ export interface MessageQueueInterfaceEvents {
 
 export interface MessageQueueInterface {
   events: TypedEventEmitter<MessageQueueInterfaceEvents>;
-  sendUsingMultiDevice(user: PubKey, message: ContentMessage): void;
-  send(device: PubKey, message: ContentMessage): void;
-  sendToGroup(message: GroupMessageType): void;
+  sendUsingMultiDevice(user: PubKey, message: ContentMessage): Promise<void>;
+  send(device: PubKey, message: ContentMessage): Promise<void>;
+  sendToGroup(message: GroupMessageType): Promise<void>;
   sendSyncMessage(message: SyncMessage | undefined): Promise<any>;
 }

--- a/ts/session/types/PubKey.ts
+++ b/ts/session/types/PubKey.ts
@@ -5,11 +5,35 @@ export class PubKey {
   );
   public readonly key: string;
 
+  /**
+   * A PubKey object.
+   * If `pubKeyString` is not valid then this will throw an `Error`.
+   *
+   * @param pubkeyString The public key string.
+   */
   constructor(pubkeyString: string) {
-    PubKey.validate(pubkeyString);
+    if (!PubKey.validate(pubkeyString)) {
+      throw new Error(`Invalid pubkey string passed: ${pubkeyString}`);
+    }
     this.key = pubkeyString;
   }
 
+  /**
+   * Cast a `value` to a `PubKey`.
+   * If `value` is not valid then this will throw.
+   *
+   * @param value The value to cast.
+   */
+  public static cast(value: string | PubKey): PubKey {
+    return typeof value === 'string' ? new PubKey(value) : value;
+  }
+
+  /**
+   * Try convert `pubKeyString` to `PubKey`.
+   *
+   * @param pubkeyString The public key string.
+   * @returns `PubKey` if valid otherwise returns `undefined`.
+   */
   public static from(pubkeyString: string): PubKey | undefined {
     // Returns a new instance if the pubkey is valid
     if (PubKey.validate(pubkeyString)) {

--- a/ts/test/session/messages/ClosedGroupChatMessage_test.ts
+++ b/ts/test/session/messages/ClosedGroupChatMessage_test.ts
@@ -6,22 +6,32 @@ import {
 } from '../../../session/messages/outgoing';
 import { SignalService } from '../../../protobuf';
 import { TextEncoder } from 'util';
+import { TestUtils } from '../../test-utils';
+import { StringUtils } from '../../../session/utils';
+import { PubKey } from '../../../session/types';
 
 describe('ClosedGroupChatMessage', () => {
+  let groupId: PubKey;
+  beforeEach(() => {
+    groupId = TestUtils.generateFakePubKey();
+  });
   it('can create empty message with timestamp, groupId and chatMessage', () => {
     const chatMessage = new ChatMessage({
       timestamp: Date.now(),
       body: 'body',
     });
     const message = new ClosedGroupChatMessage({
-      groupId: '12',
+      groupId,
       chatMessage,
     });
     const plainText = message.plainTextBuffer();
     const decoded = SignalService.Content.decode(plainText);
     expect(decoded.dataMessage)
       .to.have.property('group')
-      .to.have.deep.property('id', new TextEncoder().encode('12'));
+      .to.have.deep.property(
+        'id',
+        new Uint8Array(StringUtils.encode(groupId.key, 'utf8'))
+      );
     expect(decoded.dataMessage)
       .to.have.property('group')
       .to.have.deep.property('type', SignalService.GroupContext.Type.DELIVER);
@@ -39,7 +49,7 @@ describe('ClosedGroupChatMessage', () => {
       timestamp: Date.now(),
     });
     const message = new ClosedGroupChatMessage({
-      groupId: '12',
+      groupId,
       chatMessage,
     });
     expect(message.ttl()).to.equal(24 * 60 * 60 * 1000);
@@ -50,7 +60,7 @@ describe('ClosedGroupChatMessage', () => {
       timestamp: Date.now(),
     });
     const message = new ClosedGroupChatMessage({
-      groupId: '12',
+      groupId,
       chatMessage,
     });
     expect(message.identifier).to.not.equal(null, 'identifier cannot be null');
@@ -67,7 +77,7 @@ describe('ClosedGroupChatMessage', () => {
       identifier: 'chatMessage',
     });
     const message = new ClosedGroupChatMessage({
-      groupId: '12',
+      groupId,
       chatMessage,
       identifier: 'closedGroupMessage',
     });
@@ -81,7 +91,7 @@ describe('ClosedGroupChatMessage', () => {
       identifier: 'chatMessage',
     });
     const message = new ClosedGroupChatMessage({
-      groupId: '12',
+      groupId,
       chatMessage,
     });
     expect(message.identifier).to.be.equal('chatMessage');

--- a/ts/test/session/messages/TypingMessage_test.ts
+++ b/ts/test/session/messages/TypingMessage_test.ts
@@ -5,6 +5,8 @@ import { SignalService } from '../../../protobuf';
 import { TextEncoder } from 'util';
 import Long from 'long';
 import { toNumber } from 'lodash';
+import { StringUtils } from '../../../session/utils';
+import { TestUtils } from '../../test-utils';
 
 describe('TypingMessage', () => {
   it('has Action.STARTED if isTyping = true', () => {
@@ -60,7 +62,7 @@ describe('TypingMessage', () => {
   });
 
   it('has groupId set if a value given', () => {
-    const groupId = '6666666666';
+    const groupId = TestUtils.generateFakePubKey();
     const message = new TypingMessage({
       timestamp: Date.now(),
       isTyping: true,
@@ -68,7 +70,9 @@ describe('TypingMessage', () => {
     });
     const plainText = message.plainTextBuffer();
     const decoded = SignalService.Content.decode(plainText);
-    const manuallyEncodedGroupId = new TextEncoder().encode(groupId);
+    const manuallyEncodedGroupId = new Uint8Array(
+      StringUtils.encode(groupId.key, 'utf8')
+    );
 
     expect(decoded.typingMessage?.groupId).to.be.deep.equal(
       manuallyEncodedGroupId

--- a/ts/test/session/sending/MessageQueue_test.ts
+++ b/ts/test/session/sending/MessageQueue_test.ts
@@ -312,6 +312,13 @@ describe('MessageQueue', () => {
   });
 
   describe('sendToGroup', () => {
+    it('should throw an error if invalid non-group message was passed', async () => {
+      const chatMessage = TestUtils.generateChatMessage();
+      await expect(
+        messageQueueStub.sendToGroup(chatMessage)
+      ).to.be.rejectedWith('Invalid group message passed in sendToGroup.');
+    });
+
     describe('closed groups', async () => {
       it('can send to closed group', async () => {
         const members = TestUtils.generateFakePubKeys(4).map(
@@ -324,8 +331,7 @@ describe('MessageQueue', () => {
           .resolves();
 
         const message = TestUtils.generateClosedGroupMessage();
-        const success = await messageQueueStub.sendToGroup(message);
-        expect(success).to.equal(true, 'sending to group failed');
+        await messageQueueStub.sendToGroup(message);
         expect(sendUsingMultiDeviceStub.callCount).to.equal(members.length);
 
         const arg = sendUsingMultiDeviceStub.getCall(0).args;
@@ -342,12 +348,7 @@ describe('MessageQueue', () => {
           .resolves();
 
         const message = TestUtils.generateClosedGroupMessage();
-        const response = await messageQueueStub.sendToGroup(message);
-
-        expect(response).to.equal(
-          false,
-          'sendToGroup sent a message to an empty group'
-        );
+        await messageQueueStub.sendToGroup(message);
         expect(sendUsingMultiDeviceStub.callCount).to.equal(0);
       });
     });
@@ -365,9 +366,8 @@ describe('MessageQueue', () => {
 
       it('can send to open group', async () => {
         const message = TestUtils.generateOpenGroupMessage();
-        const success = await messageQueueStub.sendToGroup(message);
+        await messageQueueStub.sendToGroup(message);
         expect(sendToOpenGroupStub.callCount).to.equal(1);
-        expect(success).to.equal(true, 'Sending to open group failed');
       });
 
       it('should emit a success event when send was successful', async () => {


### PR DESCRIPTION
This PR updates `sendToGroup` to handle messages which have a `groupId` in them.
It also makes the `PubKey` constructor throw if invalid public key is passed which should help us in catching more errors.
