### PR TITLE
Fix closed group infinite request loop

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1861,7 +1861,8 @@
     },
 
     sendGroupInfo(recipient) {
-      if (this.isClosedGroup()) {
+      // Only send group info if we're a closed group and we haven't left
+      if (this.isClosedGroup() && !this.get('left')) {
         const updateParams = {
           timestamp: Date.now(),
           groupId: this.id,

--- a/ts/receiver/groups.ts
+++ b/ts/receiver/groups.ts
@@ -72,11 +72,14 @@ export async function preprocessGroupMessage(
       return true;
     }
   }
-  if (group.type === GROUP_TYPES.REQUEST_INFO && !newGroup) {
-    window.libloki.api.debug.logGroupRequestInfo(
-      `Received GROUP_TYPES.REQUEST_INFO from source: ${source}, primarySource: ${primarySource}, sending back group info.`
-    );
-    conversation.sendGroupInfo(source);
+  if (group.type === GROUP_TYPES.REQUEST_INFO) {
+    // We can only send the request info back if we have the information
+    if (!newGroup) {
+      window.libloki.api.debug.logGroupRequestInfo(
+        `Received GROUP_TYPES.REQUEST_INFO from source: ${source}, primarySource: ${primarySource}, sending back group info.`
+      );
+      conversation.sendGroupInfo(source);
+    }
     return true;
   }
 


### PR DESCRIPTION
This fixes an issue where `REQUEST_INFO` is continuously sent back and forth between paired devices after leaving a group.