### PR TITLE
Fix expire timer not working in closed group

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1629,9 +1629,9 @@
           fromGroupUpdate: options.fromGroupUpdate,
         },
       });
-      if (this.isPrivate()) {
-        message.set({ destination: this.id });
-      }
+
+      message.set({ destination: this.id });
+
       if (message.isOutgoing()) {
         message.set({ recipients: this.getRecipients() });
       }

--- a/ts/components/conversation/TimerNotification.tsx
+++ b/ts/components/conversation/TimerNotification.tsx
@@ -32,6 +32,10 @@ export class TimerNotification extends React.Component<Props> {
       ? 'disabledDisappearingMessages'
       : 'theyChangedTheTimer';
 
+    const displayedPubkey = profileName
+      ? window.shortenPubkey(phoneNumber)
+      : phoneNumber;
+
     switch (type) {
       case 'fromOther':
         return (
@@ -42,9 +46,11 @@ export class TimerNotification extends React.Component<Props> {
               <ContactName
                 i18n={i18n}
                 key="external-1"
-                phoneNumber={phoneNumber}
+                phoneNumber={displayedPubkey}
                 profileName={profileName}
                 name={name}
+                module="module-message__author"
+                boldProfileName={true}
               />,
               timespan,
             ]}

--- a/ts/session/messages/outgoing/content/data/ExpirationTimerUpdateMessage.ts
+++ b/ts/session/messages/outgoing/content/data/ExpirationTimerUpdateMessage.ts
@@ -32,14 +32,18 @@ export class ExpirationTimerUpdateMessage extends DataMessage {
   public dataProto(): SignalService.DataMessage {
     const data = new SignalService.DataMessage();
 
-    const groupMessage = new SignalService.GroupContext();
+    data.flags = SignalService.DataMessage.Flags.EXPIRATION_TIMER_UPDATE;
+
     if (this.groupId) {
+      const groupMessage = new SignalService.GroupContext();
       groupMessage.id = new Uint8Array(
         StringUtils.encode(this.groupId.key, 'utf8')
       );
       groupMessage.type = SignalService.GroupContext.Type.DELIVER;
+
+      data.group = groupMessage;
     }
-    data.flags = SignalService.DataMessage.Flags.EXPIRATION_TIMER_UPDATE;
+
     if (this.expireTimer) {
       data.expireTimer = this.expireTimer;
     }


### PR DESCRIPTION
We forgot to assign the group id to the message.

Also
```
message.set({ destination: this.id });
```
we do this because sync messages use `destination` when sending and it was `undefined` in groups. I figured there's no harm setting it even on groups since it doesn't seem to be used anywhere else.