### PR TITLE
Various closed group fixes

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -626,23 +626,25 @@
     window.doUpdateGroup = async (groupId, groupName, members, avatar) => {
       const ourKey = textsecure.storage.user.getNumber();
 
+      const convo = await ConversationController.getOrCreateAndWait(
+        groupId,
+        'group'
+      );
+
       const ev = {
         groupDetails: {
           id: groupId,
           name: groupName,
           members,
           active: true,
-          expireTimer: 0,
-          avatar: '',
+          expireTimer: convo.get('expireTimer'),
+          avatar,
           is_medium_group: false,
         },
         confirm: () => {},
       };
 
-      const convo = await ConversationController.getOrCreateAndWait(
-        groupId,
-        'group'
-      );
+
 
       const recipients = _.union(convo.get('members'), members);
 

--- a/js/background.js
+++ b/js/background.js
@@ -644,8 +644,6 @@
         confirm: () => {},
       };
 
-
-
       const recipients = _.union(convo.get('members'), members);
 
       await window.NewReceiver.onGroupReceived(ev);

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1900,25 +1900,28 @@
           window.console.warn('sendGroupInfo invalid pubkey:', recipient);
           return;
         }
-        await libsession
-          .getMessageQueue()
-          .send(recipientPubKey, groupUpdateMessage)
-          .catch(log.error);
 
-        const expireUpdate = {
-          timestamp: Date.now(),
-          expireTimer: this.get('expireTimer'),
-          groupId: this.get('id'),
-        };
+        try {
+          await libsession
+            .getMessageQueue()
+            .send(recipientPubKey, groupUpdateMessage);
 
-        const expirationTimerMessage = new libsession.Messages.Outgoing.ExpirationTimerUpdateMessage(
-          expireUpdate
-        );
+          const expireUpdate = {
+            timestamp: Date.now(),
+            expireTimer: this.get('expireTimer'),
+            groupId: this.get('id'),
+          };
 
-        await libsession
-          .getMessageQueue()
-          .sendUsingMultiDevice(recipientPubKey, expirationTimerMessage)
-          .catch(log.error);
+          const expirationTimerMessage = new libsession.Messages.Outgoing.ExpirationTimerUpdateMessage(
+            expireUpdate
+          );
+
+          await libsession
+            .getMessageQueue()
+            .sendUsingMultiDevice(recipientPubKey, expirationTimerMessage);
+        } catch (e) {
+          log.error('Failed to send groupInfo:', e);
+        }
       }
     },
 

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -1096,7 +1096,7 @@
           attachments,
           preview,
           quote,
-          lokiProfile: this.getOurProfile(),
+          lokiProfile: this.conversation.getOurProfile(),
         });
 
         // Special-case the self-send case - we send only a sync message

--- a/ts/components/session/SessionGroupSettings.tsx
+++ b/ts/components/session/SessionGroupSettings.tsx
@@ -222,7 +222,7 @@ export class SessionGroupSettings extends React.Component<Props, any> {
     const leaveGroupString = isPublic
       ? window.i18n('leaveOpenGroup')
       : isKickedFromGroup
-      ? window.i18n('youGotKickedFromThisGroup')
+      ? window.i18n('youGotKickedFromGroup')
       : window.i18n('leaveClosedGroup');
 
     const disappearingMessagesOptions = timerOptions.map(option => {

--- a/ts/receiver/dataMessage.ts
+++ b/ts/receiver/dataMessage.ts
@@ -435,15 +435,9 @@ export function initIncomingMessage(data: MessageCreationData): MessageModel {
   } = data;
 
   const type = 'incoming';
-  if (
-    message &&
-    message.group &&
-    message.group.id &&
-    message.group.id.length === 0
-  ) {
-    message.group.id = null;
-  }
-  const groupId = message?.group?.id;
+  const messageGroupId = message?.group?.id;
+  const groupId =
+    messageGroupId && messageGroupId.length > 0 ? messageGroupId : null;
 
   const messageData: any = {
     source,

--- a/ts/receiver/dataMessage.ts
+++ b/ts/receiver/dataMessage.ts
@@ -435,6 +435,14 @@ export function initIncomingMessage(data: MessageCreationData): MessageModel {
   } = data;
 
   const type = 'incoming';
+  if (
+    message &&
+    message.group &&
+    message.group.id &&
+    message.group.id.length === 0
+  ) {
+    message.group.id = null;
+  }
   const groupId = message?.group?.id;
 
   const messageData: any = {
@@ -614,10 +622,11 @@ export async function handleMessageEvent(event: any): Promise<void> {
   const primarySource = await MultiDeviceProtocol.getPrimaryDevice(source);
   if (isGroupMessage) {
     /* handle one part of the group logic here:
-               handle requesting info of a new group,
-               dropping an admin only update from a non admin, ...
-             */
+       handle requesting info of a new group,
+       dropping an admin only update from a non admin, ...
+    */
     conversationId = message.group.id;
+
     const shouldReturn = await preprocessGroupMessage(
       source,
       message.group,

--- a/ts/receiver/dataMessage.ts
+++ b/ts/receiver/dataMessage.ts
@@ -413,6 +413,7 @@ interface MessageCreationData {
   isRss: boolean;
   source: boolean;
   serverId: string;
+  message: any;
 
   // Needed for synced outgoing messages
   unidentifiedStatus: any; // ???
@@ -430,9 +431,11 @@ export function initIncomingMessage(data: MessageCreationData): MessageModel {
     isRss,
     source,
     serverId,
+    message,
   } = data;
 
   const type = 'incoming';
+  const groupId = message?.group?.id;
 
   const messageData: any = {
     source,
@@ -440,7 +443,7 @@ export function initIncomingMessage(data: MessageCreationData): MessageModel {
     serverId, // + (not present below in `createSentMessage`)
     sent_at: timestamp,
     received_at: receivedAt || Date.now(),
-    conversationId: source,
+    conversationId: groupId ?? source,
     unidentifiedDeliveryReceived, // +
     type,
     direction: 'incoming', // +

--- a/ts/receiver/dataMessage.ts
+++ b/ts/receiver/dataMessage.ts
@@ -70,12 +70,20 @@ export async function updateProfile(
     newProfile.avatar = null;
   }
 
-  await conversation.setLokiProfile(newProfile);
+  const allUserDevices = await MultiDeviceProtocol.getAllDevices(
+    conversation.id
+  );
+  const { ConversationController } = window;
 
-  if (conversation.isSecondaryDevice()) {
-    const primaryConversation = await conversation.getPrimaryConversation();
-    await primaryConversation.setLokiProfile(newProfile);
-  }
+  await Promise.all(
+    allUserDevices.map(async device => {
+      const conv = await ConversationController.getOrCreateAndWait(
+        device.key,
+        'private'
+      );
+      await conv.setLokiProfile(newProfile);
+    })
+  );
 }
 
 function cleanAttachment(attachment: any) {

--- a/ts/receiver/dataMessage.ts
+++ b/ts/receiver/dataMessage.ts
@@ -306,15 +306,7 @@ export async function handleDataMessage(
   }
 
   const source = envelope.senderIdentity || senderPubKey;
-
-  const isOwnDevice = async (device: string) => {
-    const pubKey = new PubKey(device);
-    const allDevices = await MultiDeviceProtocol.getAllDevices(pubKey);
-
-    return allDevices.some(d => d.isEqual(pubKey));
-  };
-
-  const ownDevice = await isOwnDevice(source);
+  const ownDevice = await MultiDeviceProtocol.isOurDevice(source);
 
   const ownMessage = conversation.isMediumGroup() && ownDevice;
 

--- a/ts/session/messages/outgoing/content/data/group/ClosedGroupUpdateMessage.ts
+++ b/ts/session/messages/outgoing/content/data/group/ClosedGroupUpdateMessage.ts
@@ -66,6 +66,8 @@ export abstract class ClosedGroupUpdateMessage extends ClosedGroupMessage {
       groupContext.admins = this.admins;
     }
 
+    groupContext.avatar = this.avatar;
+
     return groupContext;
   }
 }

--- a/ts/session/protocols/SessionProtocol.ts
+++ b/ts/session/protocols/SessionProtocol.ts
@@ -105,8 +105,6 @@ export class SessionProtocol {
   public static async sendSessionRequestIfNeeded(
     pubkey: PubKey
   ): Promise<void> {
-    const { ConversationController } = window;
-
     if (
       (await SessionProtocol.hasSession(pubkey)) ||
       (await SessionProtocol.hasSentSessionRequest(pubkey))

--- a/ts/session/utils/Protobuf.ts
+++ b/ts/session/utils/Protobuf.ts
@@ -11,6 +11,12 @@ export function convertToTS(object: any): any {
   if (
     object &&
     object.constructor &&
+    object.constructor.name === 'Uint8Array'
+  ) {
+    return object;
+  } else if (
+    object &&
+    object.constructor &&
     object.constructor.name === 'ByteBuffer'
   ) {
     return new Uint8Array(object.toArrayBuffer());

--- a/ts/session/utils/Protobuf.ts
+++ b/ts/session/utils/Protobuf.ts
@@ -8,11 +8,7 @@ import ByteBuffer from 'bytebuffer';
  */
 export function convertToTS(object: any): any {
   // No idea why js `ByteBuffer` and ts `ByteBuffer` differ ...
-  if (
-    object &&
-    object.constructor &&
-    object.constructor.name === 'Uint8Array'
-  ) {
+  if (object instanceof Uint8Array) {
     return object;
   } else if (
     object &&


### PR DESCRIPTION
* fix display name and avatar to be shown when message is coming from a secondary device
* fix show of expiretimer in the group conversation when it is for it.
* fix a bug creating empty conversation when sync closed group message is received on secondary device
* trigger an expiretimer update message to all members when updating a group.
* trigger an expiretimer update message when sending back group details (after a requestGroupInfo)