### PR TITLE
include verb and path on outgoing websocket message

### DIFF
--- a/ts/session/sending/MessageSender.ts
+++ b/ts/session/sending/MessageSender.ts
@@ -76,13 +76,14 @@ function wrapEnvelope(envelope: SignalService.Envelope): Uint8Array {
   const request = SignalService.WebSocketRequestMessage.create({
     id: 0,
     body: SignalService.Envelope.encode(envelope).finish(),
+    verb: 'PUT',
+    path: '/api/v1/message',
   });
 
   const websocket = SignalService.WebSocketMessage.create({
     type: SignalService.WebSocketMessage.Type.REQUEST,
     request,
   });
-
   return SignalService.WebSocketMessage.encode(websocket).finish();
 }
 


### PR DESCRIPTION
session v1.0.9 and before expects a `path` and `verb` to be set on websocket message, so include them so recent session versions are able to speak to one another.