### PR TITLE
hide ourdevices when creating a closed group

### DIFF
--- a/ts/components/session/SessionClosableOverlay.tsx
+++ b/ts/components/session/SessionClosableOverlay.tsx
@@ -74,7 +74,7 @@ export class SessionClosableOverlay extends React.Component<Props, State> {
       overlayMode === SessionClosableOverlayType.ClosedGroup;
     if (isClosedGroupView) {
       filteredContactsList = filteredContactsList.filter(
-        c => c.type === 'direct'
+        c => c.type === 'direct' && !c.isMe
       );
     }
 


### PR DESCRIPTION
fix our current device being shown when creating a closed group (if we have a note to self conversation)