### PR TITLE
Fix expire timer

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1925,7 +1925,12 @@
         message
       );
 
-      if (groupUpdate.joined && groupUpdate.joined.length) {
+      // send a expireTimer update message to all add members if the expireTimer is set
+      if (
+        groupUpdate.joined &&
+        groupUpdate.joined.length &&
+        this.get('expireTimer')
+      ) {
         const expireUpdate = {
           timestamp: Date.now(),
           expireTimer: this.get('expireTimer'),


### PR DESCRIPTION

Do not send an expireTimer message if the message timer is not set when a group is added to a closed group