### PR TITLE
Improve unhandled promise error logging

### DIFF
--- a/js/logging.js
+++ b/js/logging.js
@@ -136,7 +136,7 @@ window.onerror = (message, script, line, col, error) => {
 };
 
 window.addEventListener('unhandledrejection', rejectionEvent => {
-  window.log.error(
-    `Top-level unhandled promise rejection: ${rejectionEvent.reason}`
-  );
+  const error = rejectionEvent.reason;
+  const errorInfo = error && error.stack ? error.stack : JSON.stringify(error);
+  window.log.error(`Top-level unhandled promise rejection: ${errorInfo}`);
 });

--- a/password_preload.js
+++ b/password_preload.js
@@ -32,7 +32,7 @@ window.Signal = {
   Components: {
     SessionPasswordPrompt,
   },
-}
+};
 
 window.CONSTANTS = {
   MAX_LOGIN_TRIES: 3,


### PR DESCRIPTION
This PR fixes error logging in unhandled promise errors so that it prints out a stack trace.
This should help us in the future when tracking down weird errors.