### PR TITLE
Use created at server timestamp

### DIFF
--- a/app/sql.js
+++ b/app/sql.js
@@ -129,6 +129,7 @@ module.exports = {
   removeMessage,
   getUnreadByConversation,
   getMessageBySender,
+  getMessagesBySender,
   getMessageIdsFromServerIds,
   getMessageById,
   getAllMessages,
@@ -2405,6 +2406,20 @@ async function getMessageBySender({ source, sourceDevice, sent_at }) {
       $source: source,
       $sourceDevice: sourceDevice,
       $sent_at: sent_at,
+    }
+  );
+
+  return map(rows, row => jsonToObject(row.json));
+}
+
+async function getMessagesBySender({ source, sourceDevice }) {
+  const rows = await db.all(
+    `SELECT json FROM messages WHERE
+      source = $source AND
+      sourceDevice = $sourceDevice`,
+    {
+      $source: source,
+      $sourceDevice: sourceDevice,
     }
   );
 

--- a/app/sql.js
+++ b/app/sql.js
@@ -810,6 +810,7 @@ const LOKI_SCHEMA_VERSIONS = [
   updateToLokiSchemaVersion5,
   updateToLokiSchemaVersion6,
   updateToLokiSchemaVersion7,
+  updateToLokiSchemaVersion8,
 ];
 
 async function updateToLokiSchemaVersion1(currentVersion, instance) {
@@ -823,7 +824,6 @@ async function updateToLokiSchemaVersion1(currentVersion, instance) {
     `ALTER TABLE messages
      ADD COLUMN serverId INTEGER;`
   );
-
   await instance.run(
     `CREATE TABLE servers(
       serverUrl STRING PRIMARY KEY ASC,
@@ -1049,6 +1049,29 @@ async function updateToLokiSchemaVersion7(currentVersion, instance) {
 
   await instance.run('COMMIT TRANSACTION;');
   console.log('updateToLokiSchemaVersion7: success!');
+}
+
+async function updateToLokiSchemaVersion8(currentVersion, instance) {
+  if (currentVersion >= 8) {
+    return;
+  }
+  console.log('updateToLokiSchemaVersion8: starting...');
+  await instance.run('BEGIN TRANSACTION;');
+
+  await instance.run(
+    `ALTER TABLE messages
+     ADD COLUMN serverTimestamp INTEGER;`
+  );
+
+  await instance.run(
+    `INSERT INTO loki_schema (
+        version
+      ) values (
+        8
+      );`
+  );
+  await instance.run('COMMIT TRANSACTION;');
+  console.log('updateToLokiSchemaVersion8: success!');
 }
 
 async function updateLokiSchema(instance) {
@@ -2092,6 +2115,7 @@ async function saveMessage(data, { forceSave } = {}) {
     hasVisualMediaAttachments,
     id,
     serverId,
+    serverTimestamp,
     // eslint-disable-next-line camelcase
     received_at,
     schemaVersion,
@@ -2111,6 +2135,7 @@ async function saveMessage(data, { forceSave } = {}) {
     $json: objectToJSON(data),
 
     $serverId: serverId,
+    $serverTimestamp: serverTimestamp,
     $body: body,
     $conversationId: conversationId,
     $expirationStartTimestamp: expirationStartTimestamp,
@@ -2134,6 +2159,7 @@ async function saveMessage(data, { forceSave } = {}) {
       `UPDATE messages SET
         json = $json,
         serverId = $serverId,
+        serverTimestamp = $serverTimestamp,
         body = $body,
         conversationId = $conversationId,
         expirationStartTimestamp = $expirationStartTimestamp,
@@ -2169,6 +2195,7 @@ async function saveMessage(data, { forceSave } = {}) {
     json,
 
     serverId,
+    serverTimestamp,
     body,
     conversationId,
     expirationStartTimestamp,
@@ -2190,6 +2217,7 @@ async function saveMessage(data, { forceSave } = {}) {
     $json,
 
     $serverId,
+    $serverTimestamp,
     $body,
     $conversationId,
     $expirationStartTimestamp,
@@ -2419,7 +2447,7 @@ async function getMessagesByConversation(
       conversationId = $conversationId AND
       received_at < $received_at AND
       type LIKE $type
-    ORDER BY sent_at DESC
+      ORDER BY serverTimestamp DESC, serverId DESC, sent_at DESC
     LIMIT $limit;
     `,
     {

--- a/app/sql.js
+++ b/app/sql.js
@@ -110,7 +110,6 @@ module.exports = {
   getPublicConversationsByServer,
   getPubkeysInPublicConversation,
   getAllConversationIds,
-  getAllPrivateConversations,
   getAllGroupsInvolvingId,
   removeAllConversations,
   removeAllPrivateConversations,
@@ -1946,16 +1945,6 @@ async function getAllConversationIds() {
     `SELECT id FROM ${CONVERSATIONS_TABLE} ORDER BY id ASC;`
   );
   return map(rows, row => row.id);
-}
-
-async function getAllPrivateConversations() {
-  const rows = await db.all(
-    `SELECT json FROM ${CONVERSATIONS_TABLE} WHERE
-      type = 'private'
-     ORDER BY id ASC;`
-  );
-
-  return map(rows, row => jsonToObject(row.json));
 }
 
 async function getAllPublicConversations() {

--- a/background.html
+++ b/background.html
@@ -359,7 +359,6 @@
   <script type='text/javascript' src='js/views/device_pairing_dialog_view.js'></script>
   <script type='text/javascript' src='js/views/device_pairing_words_dialog_view.js'></script>
   <script type='text/javascript' src='js/views/create_group_dialog_view.js'></script>
-  <script type='text/javascript' src='js/views/confirm_session_reset_view.js'></script>
   <script type='text/javascript' src='js/views/edit_profile_dialog_view.js'></script>
   <script type='text/javascript' src='js/views/invite_contacts_dialog_view.js'></script>
   <script type='text/javascript' src='js/views/moderators_add_dialog_view.js'></script>

--- a/background_test.html
+++ b/background_test.html
@@ -362,7 +362,6 @@
   <script type='text/javascript' src='js/views/device_pairing_dialog_view.js'></script>
   <script type='text/javascript' src='js/views/device_pairing_words_dialog_view.js'></script>
   <script type='text/javascript' src='js/views/create_group_dialog_view.js'></script>
-  <script type='text/javascript' src='js/views/confirm_session_reset_view.js'></script>
   <script type='text/javascript' src='js/views/edit_profile_dialog_view.js'></script>
   <script type='text/javascript' src='js/views/invite_contacts_dialog_view.js'></script>
   <script type='text/javascript' src='js/views/moderators_add_dialog_view.js'></script>

--- a/js/background.js
+++ b/js/background.js
@@ -1326,7 +1326,7 @@
       messageReceiver = new textsecure.MessageReceiver(mySignalingKey, options);
       messageReceiver.addEventListener(
         'message',
-        window.NewReceiver.handleMessageEvent
+        window.DataMessageReceiver.handleMessageEvent
       );
       window.textsecure.messaging = new textsecure.MessageSender();
       return;
@@ -1337,11 +1337,11 @@
     messageReceiver = new textsecure.MessageReceiver(mySignalingKey, options);
     messageReceiver.addEventListener(
       'message',
-      window.NewReceiver.handleMessageEvent
+      window.DataMessageReceiver.handleMessageEvent
     );
     messageReceiver.addEventListener(
       'sent',
-      window.NewReceiver.handleMessageEvent
+      window.DataMessageReceiver.handleMessageEvent
     );
     messageReceiver.addEventListener('empty', onEmpty);
     messageReceiver.addEventListener('reconnect', onReconnect);

--- a/js/background.js
+++ b/js/background.js
@@ -1121,10 +1121,15 @@
 
     Whisper.events.on(
       'publicMessageSent',
-      ({ pubKey, timestamp, serverId }) => {
+      ({ pubKey, timestamp, serverId, serverTimestamp }) => {
         try {
           const conversation = ConversationController.get(pubKey);
-          conversation.onPublicMessageSent(pubKey, timestamp, serverId);
+          conversation.onPublicMessageSent(
+            pubKey,
+            timestamp,
+            serverId,
+            serverTimestamp
+          );
         } catch (e) {
           window.log.error('Error setting public on message');
         }

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -540,12 +540,13 @@
       await Promise.all(messages.map(m => m.setCalculatingPoW()));
     },
 
-    async onPublicMessageSent(pubKey, timestamp, serverId) {
+    async onPublicMessageSent(pubKey, timestamp, serverId, serverTimestamp) {
       const messages = this._getMessagesWithTimestamp(pubKey, timestamp);
       await Promise.all(
         messages.map(message => [
           message.setIsPublic(true),
           message.setServerId(serverId),
+          message.setServerTimestamp(serverTimestamp),
         ])
       );
     },
@@ -1294,6 +1295,9 @@
 
         if (this.isPrivate()) {
           message.set({ destination });
+        }
+        if (this.isPublic()) {
+          message.setServerTimestamp(new Date().getTime());
         }
 
         const id = await window.Signal.Data.saveMessage(message.attributes, {

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -542,13 +542,11 @@
 
     async onPublicMessageSent(pubKey, timestamp, serverId, serverTimestamp) {
       const messages = this._getMessagesWithTimestamp(pubKey, timestamp);
-      await Promise.all(
-        messages.map(message => [
-          message.setIsPublic(true),
-          message.setServerId(serverId),
-          message.setServerTimestamp(serverTimestamp),
-        ])
-      );
+      if (messages && messages.length === 1) {
+        await messages[0].setIsPublic(true);
+        await messages[0].setServerId(serverId);
+        await messages[0].setServerTimestamp(serverTimestamp);
+      }
     },
 
     async onNewMessage(message) {

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -596,6 +596,7 @@
         id: this.id,
         direction: this.isIncoming() ? 'incoming' : 'outgoing',
         timestamp: this.get('sent_at'),
+        serverTimestamp: this.get('serverTimestamp'),
         status: this.getMessagePropStatus(),
         contact: this.getPropsForEmbeddedContact(),
         authorColor,
@@ -1669,13 +1670,6 @@
 
   Whisper.MessageCollection = Backbone.Collection.extend({
     model: Whisper.Message,
-    comparator(left, right) {
-      if (left.get('sent_at') === right.get('sent_at')) {
-        return (left.get('received_at') || 0) - (right.get('received_at') || 0);
-      }
-
-      return (left.get('sent_at') || 0) - (right.get('sent_at') || 0);
-    },
     initialize(models, options) {
       if (options) {
         this.conversation = options.conversation;
@@ -1726,7 +1720,7 @@
         );
       }
 
-      this.add(models);
+      this.add(models.reverse());
 
       if (unreadCount <= 0) {
         return;

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -1441,6 +1441,19 @@
         Message: Whisper.Message,
       });
     },
+    async setServerTimestamp(serverTimestamp) {
+      if (_.isEqual(this.get('serverTimestamp'), serverTimestamp)) {
+        return;
+      }
+
+      this.set({
+        serverTimestamp,
+      });
+
+      await window.Signal.Data.saveMessage(this.attributes, {
+        Message: Whisper.Message,
+      });
+    },
     async setIsPublic(isPublic) {
       if (_.isEqual(this.get('isPublic'), isPublic)) {
         return;

--- a/js/modules/data.d.ts
+++ b/js/modules/data.d.ts
@@ -223,7 +223,6 @@ export function searchMessagesInConversation(
   conversationId: string,
   { limit }?: { limit: any }
 ): Promise<any>;
-export function getMessageCount(): Promise<number>;
 export function saveMessage(
   data: Mesasge,
   { forceSave, Message }?: { forceSave?: any; Message?: any }

--- a/js/modules/data.d.ts
+++ b/js/modules/data.d.ts
@@ -324,6 +324,7 @@ export function getMessagesByConversation(
     type?: string;
   }
 ): Promise<any>;
+
 export function getSeenMessagesByHashList(hashes: any): Promise<any>;
 export function getLastHashBySnode(convoId: any, snode: any): Promise<any>;
 

--- a/js/modules/data.d.ts
+++ b/js/modules/data.d.ts
@@ -197,7 +197,6 @@ export function getAllConversations({
 }): Promise<Array<ConversationCollection>>;
 
 export function getAllConversationIds(): Promise<Array<string>>;
-export function getAllPrivateConversations(): Promise<Array<string>>;
 export function getAllPublicConversations(): Promise<Array<string>>;
 export function getPublicConversationsByServer(
   server: string,

--- a/js/modules/data.d.ts
+++ b/js/modules/data.d.ts
@@ -267,6 +267,10 @@ export function getMessageBySender(
   }: { source: any; sourceDevice: any; sent_at: any },
   { Message }: { Message: any }
 ): Promise<any>;
+export function getMessagesBySender(
+  { source, sourceDevice }: { source: any; sourceDevice: any },
+  { Message }: { Message: any }
+): Promise<Whisper.MessageCollection>;
 export function getMessageIdsFromServerIds(
   serverIds: any,
   conversationId: any

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -123,7 +123,6 @@ module.exports = {
 
   getAllConversations,
   getAllConversationIds,
-  getAllPrivateConversations,
   getAllPublicConversations,
   getPublicConversationsByServer,
   getPubkeysInPublicConversation,
@@ -813,14 +812,6 @@ async function getAllConversationIds() {
 
 async function getAllPublicConversations({ ConversationCollection }) {
   const conversations = await channels.getAllPublicConversations();
-
-  const collection = new ConversationCollection();
-  collection.add(conversations);
-  return collection;
-}
-
-async function getAllPrivateConversations({ ConversationCollection }) {
-  const conversations = await channels.getAllPrivateConversations();
 
   const collection = new ConversationCollection();
   collection.add(conversations);

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -151,6 +151,7 @@ module.exports = {
   removeAllMessagesInConversation,
 
   getMessageBySender,
+  getMessagesBySender,
   getMessageIdsFromServerIds,
   getMessageById,
   getAllMessages,
@@ -1013,6 +1014,23 @@ async function getMessageBySender(
   }
 
   return new Message(messages[0]);
+}
+
+async function getMessagesBySender(
+  // eslint-disable-next-line camelcase
+  { source, sourceDevice, sent_at },
+  { Message }
+) {
+  const messages = await channels.getMessageBySender({
+    source,
+    sourceDevice,
+    sent_at,
+  });
+  if (!messages || !messages.length) {
+    return null;
+  }
+
+  return messages.map(m => new Message(m));
 }
 
 async function getUnreadByConversation(conversationId, { MessageCollection }) {

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -134,7 +134,6 @@ module.exports = {
   searchMessages,
   searchMessagesInConversation,
 
-  getMessageCount,
   saveMessage,
   cleanSeenMessages,
   cleanLastHashes,
@@ -874,9 +873,6 @@ async function searchMessagesInConversation(
 }
 
 // Message
-async function getMessageCount() {
-  return channels.getMessageCount();
-}
 
 async function cleanSeenMessages() {
   await channels.cleanSeenMessages();

--- a/js/modules/data.js
+++ b/js/modules/data.js
@@ -1005,13 +1005,12 @@ async function getMessageBySender(
 
 async function getMessagesBySender(
   // eslint-disable-next-line camelcase
-  { source, sourceDevice, sent_at },
+  { source, sourceDevice },
   { Message }
 ) {
-  const messages = await channels.getMessageBySender({
+  const messages = await channels.getMessagesBySender({
     source,
     sourceDevice,
-    sent_at,
   });
   if (!messages || !messages.length) {
     return null;

--- a/js/modules/loki_app_dot_net_api.d.ts
+++ b/js/modules/loki_app_dot_net_api.d.ts
@@ -30,7 +30,7 @@ export interface LokiPublicChannelAPI {
       body?: string;
     },
     timestamp: number
-  ): Promise<number>;
+  ): Promise<{ serverId; serverTimestamp }>;
 }
 
 declare class LokiAppDotNetServerAPI implements LokiAppDotNetServerInterface {

--- a/js/modules/loki_app_dot_net_api.js
+++ b/js/modules/loki_app_dot_net_api.js
@@ -1799,7 +1799,9 @@ class LokiPublicChannelAPI {
     }
 
     return {
-      timestamp: new Date(`${adnMessage.created_at}`).getTime() || timestamp,
+      timestamp,
+      serverTimestamp:
+        new Date(`${adnMessage.created_at}`).getTime() || timestamp,
       attachments,
       preview,
       quote,
@@ -1919,6 +1921,7 @@ class LokiPublicChannelAPI {
         adnMessage.body = messengerData.text;
         const {
           timestamp,
+          serverTimestamp,
           quote,
           attachments,
           preview,
@@ -1990,9 +1993,9 @@ class LokiPublicChannelAPI {
           isSessionRequest: false,
           source: pubKey,
           sourceDevice: 1,
-          timestamp,
+          timestamp, // sender timestamp
 
-          serverTimestamp: timestamp,
+          serverTimestamp, // server created_at, used to order messages
           receivedAt,
           isPublic: true,
           message: {
@@ -2008,7 +2011,7 @@ class LokiPublicChannelAPI {
             profileKey,
             timestamp,
             received_at: receivedAt,
-            sent_at: timestamp,
+            sent_at: timestamp, // sender timestamp inner
             quote,
             contact: [],
             preview,

--- a/js/modules/loki_app_dot_net_api.js
+++ b/js/modules/loki_app_dot_net_api.js
@@ -1950,10 +1950,10 @@ class LokiPublicChannelAPI {
         this.lastMessagesCache = [
           ...this.lastMessagesCache,
           {
-            propsForMessage: {
-              authorPhoneNumber: pubKey,
-              text: adnMessage.text,
-              timestamp,
+            attributes: {
+              source: pubKey,
+              body: adnMessage.text,
+              sent_at: timestamp,
             },
           },
         ].splice(-5);

--- a/js/modules/loki_app_dot_net_api.js
+++ b/js/modules/loki_app_dot_net_api.js
@@ -2345,7 +2345,10 @@ class LokiPublicChannelAPI {
       objBody: payload,
     });
     if (!res.err && res.response) {
-      return res.response.data.id;
+      return {
+        serverId: res.response.data.id,
+        serverTimestamp: new Date(`${res.response.data.created_at}`).getTime(),
+      };
     }
     if (res.err) {
       log.error(`POST ${this.baseChannelUrl}/messages failed`);
@@ -2357,9 +2360,8 @@ class LokiPublicChannelAPI {
     } else {
       log.warn(res.response);
     }
-    // there's no retry on desktop
-    // this is supposed to be after retries
-    return -1;
+
+    return { serverId: -1, serverTimestamp: -1 };
   }
 }
 

--- a/js/modules/loki_message_api.js
+++ b/js/modules/loki_message_api.js
@@ -60,7 +60,8 @@ class LokiMessageAPI {
           'Failed to send public chat message'
         );
       }
-      messageEventData.serverId = res;
+      messageEventData.serverId = res.serverId;
+      messageEventData.serverTimestamp = res.serverTimestamp;
       window.Whisper.events.trigger('publicMessageSent', messageEventData);
       return;
     }

--- a/preload.js
+++ b/preload.js
@@ -420,6 +420,7 @@ window.addEventListener('contextmenu', e => {
 });
 
 window.NewReceiver = require('./ts/receiver/receiver');
+window.DataMessageReceiver = require('./ts/receiver/dataMessage');
 window.NewSnodeAPI = require('./ts/session/snode_api/serviceNodeAPI');
 window.SnodePool = require('./ts/session/snode_api/snodePool');
 

--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -1203,7 +1203,9 @@
 }
 
 .module-message-detail__unix-timestamp {
-  color: $color-light-10;
+  @include themify($themes) {
+    color: subtle(themed('textColor'));
+  }
 }
 
 .module-message-detail__delete-button-container {

--- a/stylesheets/_session.scss
+++ b/stylesheets/_session.scss
@@ -370,7 +370,10 @@ $session-element-border-green: 4px solid $session-color-green;
   font-size: $session-font-md;
 
   &-text {
-    @include session-color-subtle($session-color-white);
+    @include themify($themes) {
+      @include session-color-subtle(themed('textColor'));
+    }
+
     font-family: $session-font-default;
     font-weight: 300;
     font-size: $session-font-xs;

--- a/stylesheets/_theme_dark.scss
+++ b/stylesheets/_theme_dark.scss
@@ -604,10 +604,6 @@
 
   // Module: Message Detail
 
-  .module-message-detail__unix-timestamp {
-    color: $color-dark-55;
-  }
-
   .module-message-detail__delete-button {
     background-color: $session-color-danger;
     color: $color-white;

--- a/test/index.html
+++ b/test/index.html
@@ -370,7 +370,6 @@
   <script type="text/javascript" src="../js/views/device_pairing_dialog_view.js"></script>
   <script type="text/javascript" src="../js/views/device_pairing_words_dialog_view.js"></script>
   <script type="text/javascript" src="../js/views/create_group_dialog_view.js"></script>
-  <script type="text/javascript" src="../js/views/confirm_session_reset_view.js"></script>
   <script type="text/javascript" src="../js/views/edit_profile_dialog_view.js"></script>
   <script type="text/javascript" src="../js/views/invite_contacts_dialog_view.js"></script>
   <script type="text/javascript" src="../js/views/moderators_add_dialog_view.js"></script>

--- a/ts/components/conversation/Message.tsx
+++ b/ts/components/conversation/Message.tsx
@@ -65,6 +65,7 @@ export interface Props {
   collapseMetadata?: boolean;
   direction: 'incoming' | 'outgoing';
   timestamp: number;
+  serverTimestamp?: number;
   status?: 'sending' | 'sent' | 'delivered' | 'read' | 'error';
   // What if changed this over to a single contact like quote, and put the events on it?
   contact?: Contact & {
@@ -257,6 +258,7 @@ export class Message extends React.PureComponent<Props, State> {
       text,
       textPending,
       timestamp,
+      serverTimestamp,
     } = this.props;
 
     if (collapseMetadata) {
@@ -299,7 +301,7 @@ export class Message extends React.PureComponent<Props, State> {
         ) : (
           <Timestamp
             i18n={i18n}
-            timestamp={timestamp}
+            timestamp={serverTimestamp || timestamp}
             extended={true}
             direction={direction}
             withImageNoCaption={withImageNoCaption}

--- a/ts/receiver/dataMessage.ts
+++ b/ts/receiver/dataMessage.ts
@@ -446,6 +446,7 @@ interface MessageCreationData {
   source: boolean;
   serverId: string;
   message: any;
+  serverTimestamp: any;
 
   // Needed for synced outgoing messages
   unidentifiedStatus: any; // ???
@@ -464,6 +465,7 @@ export function initIncomingMessage(data: MessageCreationData): MessageModel {
     source,
     serverId,
     message,
+    serverTimestamp,
   } = data;
 
   const type = 'incoming';
@@ -476,6 +478,7 @@ export function initIncomingMessage(data: MessageCreationData): MessageModel {
     sourceDevice,
     serverId, // + (not present below in `createSentMessage`)
     sent_at: timestamp,
+    serverTimestamp,
     received_at: receivedAt || Date.now(),
     conversationId: groupId ?? source,
     unidentifiedDeliveryReceived, // +

--- a/ts/receiver/multidevice.ts
+++ b/ts/receiver/multidevice.ts
@@ -4,7 +4,7 @@ import { EnvelopePlus } from './types';
 import * as Data from '../../js/modules/data';
 
 import { SignalService } from '../protobuf';
-import { updateProfile } from './receiver';
+import { updateProfile } from './dataMessage';
 import { onVerified } from './syncMessages';
 
 import { StringUtils } from '../session/utils';

--- a/ts/receiver/receiver.ts
+++ b/ts/receiver/receiver.ts
@@ -19,27 +19,14 @@ import _ from 'lodash';
 
 export { processMessage, onDeliveryReceipt };
 
-import {
-  handleDataMessage,
-  handleMessageEvent,
-  updateProfile,
-} from './dataMessage';
+import { handleMessageEvent, updateProfile } from './dataMessage';
 
 import { getEnvelopeId } from './common';
 import { StringUtils } from '../session/utils';
 import { SignalService } from '../protobuf';
-import { BlockedNumberController } from '../util/blockedNumberController';
 import { MultiDeviceProtocol } from '../session/protocols';
 
 // TODO: check if some of these exports no longer needed
-export {
-  handleEndSession,
-  handleMediumGroupUpdate,
-  downloadAttachment,
-  handleDataMessage,
-  updateProfile,
-  handleMessageEvent,
-};
 
 interface ReqOptions {
   conversationId: string;

--- a/ts/receiver/syncMessages.ts
+++ b/ts/receiver/syncMessages.ts
@@ -11,14 +11,12 @@ import {
   handleMessageEvent,
   isMessageEmpty,
   processDecrypted,
+  updateProfile,
 } from './dataMessage';
-import { updateProfile } from './receiver';
 import { handleContacts } from './multidevice';
 import { updateOrCreateGroupFromSync } from '../session/medium_group';
 import { MultiDeviceProtocol } from '../session/protocols';
-import { DataMessage } from '../session/messages/outgoing';
 import { BlockedNumberController } from '../util';
-import { StringUtils } from '../session/utils';
 
 export async function handleSyncMessage(
   envelope: EnvelopePlus,

--- a/ts/session/sending/MessageQueue.ts
+++ b/ts/session/sending/MessageQueue.ts
@@ -62,13 +62,14 @@ export class MessageQueue implements MessageQueueInterface {
       try {
         const result = await MessageSender.sendToOpenGroup(message);
         // sendToOpenGroup returns -1 if failed or an id if succeeded
-        if (result < 0) {
+        if (result.serverId < 0) {
           this.events.emit('fail', message, error);
         } else {
           const messageEventData = {
             pubKey: message.group.groupId,
             timestamp: message.timestamp,
-            serverId: result,
+            serverId: result.serverId,
+            serverTimestamp: result.serverTimestamp,
           };
           this.events.emit('success', message);
 

--- a/ts/session/sending/MessageSender.ts
+++ b/ts/session/sending/MessageSender.ts
@@ -98,7 +98,7 @@ function wrapEnvelope(envelope: SignalService.Envelope): Uint8Array {
  */
 export async function sendToOpenGroup(
   message: OpenGroupMessage
-): Promise<number> {
+): Promise<{ serverId: number; serverTimestamp: number }> {
   /*
     Note: Retrying wasn't added to this but it can be added in the future if needed.
     The only problem is that `channelAPI.sendMessage` returns true/false and doesn't throw any error so we can never be sure why sending failed.
@@ -112,7 +112,7 @@ export async function sendToOpenGroup(
   );
 
   if (!channelAPI) {
-    return -1;
+    return { serverId: -1, serverTimestamp: -1 };
   }
 
   // Returns -1 on fail or an id > 0 on success

--- a/ts/test/session/unit/sending/MessageQueue_test.ts
+++ b/ts/test/session/unit/sending/MessageQueue_test.ts
@@ -27,6 +27,7 @@ chai.use(chaiAsPromised);
 
 const { expect } = chai;
 
+// tslint:disable-next-line: max-func-body-length
 describe('MessageQueue', () => {
   // Initialize new stubbed cache
   const sandbox = sinon.createSandbox();
@@ -336,7 +337,7 @@ describe('MessageQueue', () => {
       });
 
       it('should emit a success event when send was successful', async () => {
-        sendToOpenGroupStub.resolves({ serverId: -1, serverTimestamp: -1 });
+        sendToOpenGroupStub.resolves({ serverId: 5125, serverTimestamp: 5125 });
 
         const message = TestUtils.generateOpenGroupMessage();
         const eventPromise = PromiseUtils.waitForTask(complete => {

--- a/ts/test/session/unit/sending/MessageQueue_test.ts
+++ b/ts/test/session/unit/sending/MessageQueue_test.ts
@@ -321,12 +321,12 @@ describe('MessageQueue', () => {
     describe('open groups', async () => {
       let sendToOpenGroupStub: sinon.SinonStub<
         [OpenGroupMessage],
-        Promise<number>
+        Promise<{ serverId: number; serverTimestamp: number }>
       >;
       beforeEach(() => {
         sendToOpenGroupStub = sandbox
           .stub(MessageSender, 'sendToOpenGroup')
-          .resolves(-1);
+          .resolves({ serverId: -1, serverTimestamp: -1 });
       });
 
       it('can send to open group', async () => {
@@ -336,7 +336,7 @@ describe('MessageQueue', () => {
       });
 
       it('should emit a success event when send was successful', async () => {
-        sendToOpenGroupStub.resolves(123456);
+        sendToOpenGroupStub.resolves({ serverId: -1, serverTimestamp: -1 });
 
         const message = TestUtils.generateOpenGroupMessage();
         const eventPromise = PromiseUtils.waitForTask(complete => {
@@ -348,7 +348,7 @@ describe('MessageQueue', () => {
       });
 
       it('should emit a fail event if something went wrong', async () => {
-        sendToOpenGroupStub.resolves(-1);
+        sendToOpenGroupStub.resolves({ serverId: -1, serverTimestamp: -1 });
         const message = TestUtils.generateOpenGroupMessage();
         const eventPromise = PromiseUtils.waitForTask(complete => {
           messageQueueStub.events.once('fail', complete);


### PR DESCRIPTION
Order messages received by the server created_at timestamp rather than the one included in the message.
This is to prevent messages from a user with an out of sync clock to be able to sent message way in the past or in the future.

Also changes the way we check for duplicates. As we now rely on the server timestamp, we have a difference of timestamp between the message we sent, and the message the server sent us back on pull. This creates two messages on desktop. The way to fix it is to add a timeframe of 10s during a which, a message from a specific user and with the same content will be considered a duplicate, and so will be dropped