### PR TITLE
Fix emoji panel

### DIFF
--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -29,6 +29,7 @@
     display: flex;
     flex-direction: column;
     flex-grow: 1;
+    width: 100%;
   }
 
   .main.panel {


### PR DESCRIPTION
Fix the size of the conversation panel. 
If the window was too small, sent messages were not visible, and the emoji panel was too big.

Needs https://github.com/loki-project/session-desktop/pull/1320 to be merged first. The only interesting commit is the last one.