### PR TITLE
Fix read setting marking read

### DIFF
--- a/app/tray_icon.js
+++ b/app/tray_icon.js
@@ -65,12 +65,12 @@ function createTrayIcon(getMainWindow, messages) {
     trayContextMenu = Menu.buildFromTemplate([
       {
         id: 'toggleWindowVisibility',
-        label: messages[mainWindow.isVisible() ? 'hide' : 'show'].message,
+        label: messages[mainWindow.isVisible() ? 'appMenuHide' : 'show'].message,
         click: tray.toggleWindowVisibility,
       },
       {
         id: 'quit',
-        label: messages.quit.message,
+        label: messages.appMenuQuit.message,
         click: app.quit.bind(app),
       },
     ]);

--- a/app/tray_icon.js
+++ b/app/tray_icon.js
@@ -65,7 +65,8 @@ function createTrayIcon(getMainWindow, messages) {
     trayContextMenu = Menu.buildFromTemplate([
       {
         id: 'toggleWindowVisibility',
-        label: messages[mainWindow.isVisible() ? 'appMenuHide' : 'show'].message,
+        label:
+          messages[mainWindow.isVisible() ? 'appMenuHide' : 'show'].message,
         click: tray.toggleWindowVisibility,
       },
       {

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -391,7 +391,10 @@
       this.window.addEventListener('resize', this.onResize);
 
       this.onFocus = () => {
-        if (this.$el.css('display') !== 'none') {
+        if (
+          this.$el.css('display') !== 'none' &&
+          this.$el.css('display') !== ''
+        ) {
           this.markRead();
         }
       };


### PR DESCRIPTION
Bug reported by Brice

* Enabling read-receipt setting would make a conversation open in the stack but not on foreground mark its message as read as they were coming in.
* the issue was the way we were checking for which conversation is in foreground or not.
