### PR TITLE
fix out dated parameters to findOrCreateChannel for open group invites

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -991,22 +991,21 @@
           return;
         }
 
-        const serverAPI = await window.lokiPublicChatAPI.findOrCreateServer(
-          sslServerUrl
-        );
-        if (!serverAPI) {
-          window.log.warn(`Could not connect to ${serverAddress}`);
-          return;
-        }
-
         const conversation = await ConversationController.getOrCreateAndWait(
           conversationId,
           'group'
         );
-
-        serverAPI.findOrCreateChannel(channelId, conversationId);
         await conversation.setPublicSource(sslServerUrl, channelId);
 
+        const channelAPI = await window.lokiPublicChatAPI.findOrCreateChannel(
+          sslServerUrl,
+          channelId,
+          conversationId
+        );
+        if (!channelAPI) {
+          window.log.warn(`Could not connect to ${serverAddress}`);
+          return;
+        }
         appView.openConversation(conversationId, {});
       }
     );


### PR DESCRIPTION
LokiAppDotNetServerAPI::findOrCreateChannel now takes 3 parameters, and open group invites call here wasn't updated.

Changed to use the more standard LokiPublicChatAPI::findOrCreateChannel

This fixes Open Group Invites