### PR TITLE
allow closed group updates from non-admin user

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -270,7 +270,6 @@
         };
       };
       const getGroupSettingsProps = () => {
-        const ourPK = window.textsecure.storage.user.getNumber();
         const members = this.model.get('members') || [];
 
         return {
@@ -281,7 +280,7 @@
           avatarPath: this.model.getAvatarPath(),
           isGroup: !this.model.isPrivate(),
           isPublic: this.model.isPublic(),
-          isAdmin: this.model.get('groupAdmins').includes(ourPK),
+          isAdmin: true, // allow closed group edits from anyone this.model.get('groupAdmins').includes(ourPK),
           isRss: this.model.isRss(),
           memberCount: members.length,
           amMod: this.model.isModerator(

--- a/js/views/create_group_dialog_view.js
+++ b/js/views/create_group_dialog_view.js
@@ -21,9 +21,8 @@
       this.members = groupConvo.get('members') || [];
       this.avatarPath = groupConvo.getAvatarPath();
 
-      const ourPK = textsecure.storage.user.getNumber();
-
-      this.isAdmin = groupConvo.get('groupAdmins').includes(ourPK);
+      // any member can update a closed group name
+      this.isAdmin = true;
 
       // public chat settings overrides
       if (this.isPublic) {
@@ -79,7 +78,6 @@
   Whisper.UpdateGroupMembersDialogView = Whisper.View.extend({
     className: 'loki-dialog modal',
     initialize(groupConvo) {
-      const ourPK = textsecure.storage.user.getNumber();
       this.groupName = groupConvo.get('name');
       this.close = this.close.bind(this);
       this.onSubmit = this.onSubmit.bind(this);
@@ -99,7 +97,8 @@
         this.existingMembers = [];
       } else {
         this.titleText = i18n('updateGroupDialogTitle', this.groupName);
-        this.isAdmin = groupConvo.get('groupAdmins').includes(ourPK);
+        // anybody can edit a closed group name or members
+        this.isAdmin = true;
         const convos = window.getConversations().models.filter(d => !!d);
 
         this.existingMembers = groupConvo.get('members') || [];

--- a/ts/components/session/SessionGroupSettings.tsx
+++ b/ts/components/session/SessionGroupSettings.tsx
@@ -245,7 +245,7 @@ class SessionGroupSettings extends React.Component<Props, any> {
     const showUpdateGroupNameButton =
       isPublic && !isKickedFromGroup
         ? amMod && !isBlocked
-        : isAdmin && !isBlocked;
+        : isAdmin && !isBlocked && !isKickedFromGroup;
     const showUpdateGroupMembersButton =
       !isPublic && !isKickedFromGroup && !isBlocked && isAdmin;
 

--- a/ts/receiver/groups.ts
+++ b/ts/receiver/groups.ts
@@ -85,9 +85,8 @@ export async function preprocessGroupMessage(
     if (newGroup) {
       conversation.updateGroupAdmins(group.admins);
     } else {
-      // be sure to drop a message from a non admin if it tries to change group members
-      // or change the group name
-      const fromAdmin = conversation.get('groupAdmins').includes(primarySource);
+      // group members and names can be changed from any member
+      const fromAdmin = true;
 
       if (!fromAdmin) {
         // Make sure the message is not removing members / renaming the group


### PR DESCRIPTION
Any member of a closed group can now update a group name or group members.