### PR TITLE
Add --vs2015 to windows setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Then you need `git`, if you don't have that yet: https://git-scm.com/
       https://www.microsoft.com/en-us/download/details.aspx?id=40773
     * Install Windows SDK version 8.1: https://developer.microsoft.com/en-us/windows/downloads/sdk-archive
 1.  Install _Windows Build Tools_: Open the [Command Prompt (`cmd.exe`) as Administrator](<https://technet.microsoft.com/en-us/library/cc947813(v=ws.10).aspx>)
-    and run: `npm install --global --production --add-python-to-path windows-build-tools`
+    and run: `npm install --vs2015 --global --production --add-python-to-path windows-build-tools`
 
 ### Linux
 


### PR DESCRIPTION
### Contributor checklist:

* [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
* [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`clearnet`](https://github.com/loki-project/loki-messenger/tree/clearnet) branch
* [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/loki-project/loki-messenger/blob/master/CONTRIBUTING.md#tests))
* [x] My changes are ready to be shipped to users

### Description
Session requires like Signal vs2015 Windows Build tools for some reason.

So I added this info to the Contributing Guide to give more love to the Windows Dev Bois
