### PR TITLE
Fix open group file uploads using incorrect server

### DIFF
--- a/js/modules/loki_app_dot_net_api.d.ts
+++ b/js/modules/loki_app_dot_net_api.d.ts
@@ -9,6 +9,11 @@ interface UploadResponse {
   id?: number;
 }
 
+interface DownloadResponse {
+  statucCode: number;
+  reponse: any;
+}
+
 export interface LokiAppDotNetServerInterface {
   findOrCreateChannel(
     api: LokiPublicChatFactoryAPI,
@@ -19,6 +24,7 @@ export interface LokiAppDotNetServerInterface {
   uploadAvatar(data: FormData): Promise<UploadResponse>;
   putAttachment(data: ArrayBuffer): Promise<UploadResponse>;
   putAvatar(data: ArrayBuffer): Promise<UploadResponse>;
+  downloadAttachment(url: String): Promise<DownloadResponse>; // todo: add return type
 }
 
 export interface LokiPublicChannelAPI {


### PR DESCRIPTION
File uploads in open groups live on their own fileserver. While we were uploading to the right server, when downloading we always used file.getsession.org. Ideally each attachment should remember which server/API it belongs to, but all we have right now it the url (which might be mangled: uploading to `file.getsession.org` might procude an attachment with url `file-static.getsession.org`...). Current this PR adds a workaround that tries to connect to the right server based on that url.