### PR TITLE
fix restoring of session after restore from seed

### DIFF
--- a/js/models/conversations.d.ts
+++ b/js/models/conversations.d.ts
@@ -92,7 +92,7 @@ export interface ConversationModel
   makeQuote: any;
   unblock: any;
   deleteContact: any;
-  endSession: any;
+  endSession: () => Promise<void>;
   block: any;
   copyPublicKey: any;
   getAvatar: any;

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1547,14 +1547,6 @@
     },
     async onSessionResetReceived() {
       await this.setSessionResetStatus(SessionResetEnum.request_received);
-      // send empty message, this will trigger the new session to propagate
-      // to the reset initiator.
-      const user = new libsession.Types.PubKey(this.id);
-
-      const sessionEstablished = new window.libsession.Messages.Outgoing.SessionEstablishedMessage(
-        { timestamp: Date.now() }
-      );
-      await libsession.getMessageQueue().send(user, sessionEstablished);
     },
 
     isSessionResetReceived() {

--- a/js/signal_protocol_store.js
+++ b/js/signal_protocol_store.js
@@ -232,8 +232,7 @@
         };
       }
 
-      window.log.error('Failed to fetch prekey:', keyId);
-      return undefined;
+      throw new textsecure.PreKeyMissing();
     },
     async loadPreKeyForContact(contactPubKey) {
       const key = await window.Signal.Data.getPreKeyByRecipient(contactPubKey);

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -928,10 +928,6 @@
       }
     },
 
-    endSession() {
-      this.model.endSession();
-    },
-
     setDisappearingMessages(seconds) {
       if (seconds > 0) {
         this.model.updateExpirationTimer(seconds);

--- a/libtextsecure/errors.js
+++ b/libtextsecure/errors.js
@@ -226,6 +226,18 @@
     }
   }
 
+  function PreKeyMissing() {
+    this.name = 'PreKeyMissing';
+
+    Error.call(this, this.name);
+
+    // Maintains proper stack trace, where our error was thrown (only available on V8)
+    //   via https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this);
+    }
+  }
+
   window.textsecure.SendMessageNetworkError = SendMessageNetworkError;
   window.textsecure.IncomingIdentityKeyError = IncomingIdentityKeyError;
   window.textsecure.OutgoingIdentityKeyError = OutgoingIdentityKeyError;
@@ -243,4 +255,5 @@
   window.textsecure.PublicChatError = PublicChatError;
   window.textsecure.PublicTokenError = PublicTokenError;
   window.textsecure.SenderKeyMissing = SenderKeyMissing;
+  window.textsecure.PreKeyMissing = PreKeyMissing;
 })();

--- a/libtextsecure/index.d.ts
+++ b/libtextsecure/index.d.ts
@@ -21,5 +21,6 @@ export interface LibTextsecure {
   PublicChatError: any;
   PublicTokenError: any;
   SenderKeyMissing: any;
+  PreKeyMissing: any;
   createTaskWithTimeout(task: any, id: any, options?: any): Promise<any>;
 }

--- a/ts/components/session/conversation/SessionConversation.tsx
+++ b/ts/components/session/conversation/SessionConversation.tsx
@@ -447,7 +447,7 @@ export class SessionConversation extends React.Component<Props, State> {
       },
       onDeleteContact: () => conversation.deleteContact(),
       onResetSession: () => {
-        conversation.endSession();
+        void conversation.endSession();
       },
 
       onShowSafetyNumber: () => {

--- a/ts/receiver/dataMessage.ts
+++ b/ts/receiver/dataMessage.ts
@@ -286,14 +286,16 @@ export async function handleDataMessage(
     return;
   }
 
-  // tslint:disable-next-line no-bitwise
+  // tslint:disable no-bitwise
   if (
     dataMessage.flags &&
     dataMessage.flags & SignalService.DataMessage.Flags.END_SESSION
   ) {
     await handleEndSession(envelope.source);
-    return;
+    return removeFromCache(envelope);
   }
+  // tslint:enable no-bitwise
+
   const message = await processDecrypted(envelope, dataMessage);
   const ourPubKey = window.textsecure.storage.user.getNumber();
   const senderPubKey = envelope.senderIdentity || envelope.source;
@@ -302,7 +304,7 @@ export async function handleDataMessage(
 
   const { UNPAIRING_REQUEST } = SignalService.DataMessage.Flags;
 
-  // eslint-disable-next-line no-bitwise
+  // tslint:disable-next-line: no-bitwise
   const isUnpairingRequest = Boolean(message.flags & UNPAIRING_REQUEST);
 
   if (isUnpairingRequest) {

--- a/ts/receiver/sessionHandling.ts
+++ b/ts/receiver/sessionHandling.ts
@@ -14,6 +14,8 @@ export async function handleEndSession(number: string): Promise<void> {
   try {
     const conversation = ConversationController.get(number);
     if (conversation) {
+      // this just marks the conversation as being waiting for a new session
+      // it does trigger a message to be sent. (the message is sent from handleSessionRequestMessage())
       await conversation.onSessionResetReceived();
     } else {
       throw new Error();
@@ -27,7 +29,7 @@ export async function handleSessionRequestMessage(
   envelope: EnvelopePlus,
   preKeyBundleMessage: SignalService.IPreKeyBundleMessage
 ) {
-  const { libsignal, libloki, StringView, textsecure, dcodeIO, log } = window;
+  const { libsignal, StringView, textsecure, dcodeIO, log } = window;
 
   window.console.log(
     `Received SESSION_REQUEST from source: ${envelope.source}`

--- a/ts/session/messages/outgoing/content/SessionRequestMessage.ts
+++ b/ts/session/messages/outgoing/content/SessionRequestMessage.ts
@@ -2,6 +2,7 @@ import { ContentMessage } from './ContentMessage';
 import { SignalService } from '../../../../protobuf';
 import { MessageParams } from '../Message';
 import { Constants } from '../../..';
+import * as crypto from 'crypto';
 
 export interface PreKeyBundleType {
   identityKey: Uint8Array;
@@ -19,10 +20,19 @@ interface SessionRequestParams extends MessageParams {
 
 export class SessionRequestMessage extends ContentMessage {
   private readonly preKeyBundle: PreKeyBundleType;
+  private readonly padding: Buffer;
 
   constructor(params: SessionRequestParams) {
     super({ timestamp: params.timestamp, identifier: params.identifier });
     this.preKeyBundle = params.preKeyBundle;
+    // Generate a random int from 1 and 512
+    const buffer = crypto.randomBytes(1);
+
+    // tslint:disable-next-line: no-bitwise
+    const paddingLength = (new Uint8Array(buffer)[0] & 0x1ff) + 1;
+
+    // Generate a random padding buffer of the chosen size
+    this.padding = crypto.randomBytes(paddingLength);
   }
 
   public ttl(): number {
@@ -36,7 +46,7 @@ export class SessionRequestMessage extends ContentMessage {
   protected contentProto(): SignalService.Content {
     const nullMessage = new SignalService.NullMessage({});
     const preKeyBundleMessage = this.getPreKeyBundleMessage();
-
+    nullMessage.padding = this.padding;
     return new SignalService.Content({
       nullMessage,
       preKeyBundleMessage,


### PR DESCRIPTION
Fix the restoring from seed when one of the coming message is a prekey.

BEFORE RESTORING FROM SEED
""""""""""""""""""""""""""
B sends to A some messages, triggering the creation of a preKeyBundle of ID lets say 1.
B sends this preKeyBundle as a SESSION_REQUEST message
B stores this preKeyBundle and waits for A to reply for a SESSION_CREATED message.
When B gets that message (it can be any message not encoded with prekey), B removes this prekey from it's database.
At this point A and B can communicate.


'A' RESTORES FROM SEED
""""""""""""""""""""""
When A restores from seed he gets the preKeyBundle of ID 1, again. (if less than the time it is stored on snodes.)
But B, already burnt that preKeyBundle.
A thinks he is creating a working session with B but he is not.
As long as B does not tell to A that the preKeyBundle cannot be used, there is no way out (except removing the session with A from B).
